### PR TITLE
feat: [FE2-03a] polish account details pages for personal and business

### DIFF
--- a/cypress/e2e/account-details.cy.ts
+++ b/cypress/e2e/account-details.cy.ts
@@ -1,0 +1,379 @@
+/// <reference types="cypress" />
+
+const MOCK_ACCOUNT = {
+  id: 1, accountNumber: '265000000000000112', name: 'Tekuci racun - RSD',
+  accountType: 'TEKUCI', accountSubtype: 'STANDARDNI', status: 'ACTIVE',
+  balance: 500000, availableBalance: 485230.5, reservedBalance: 14769.5,
+  dailyLimit: 200000, monthlyLimit: 1000000, dailySpending: 45000,
+  monthlySpending: 150000, maintenanceFee: 250, currency: 'RSD',
+  ownerName: 'Stefan Jovanovic', createdAt: '2025-01-15',
+};
+
+const MOCK_BUSINESS_ACCOUNT = {
+  ...MOCK_ACCOUNT,
+  id: 3, accountNumber: '265000000000000336', name: 'Poslovni racun - RSD',
+  accountType: 'POSLOVNI', accountSubtype: 'DOO', balance: 2800000,
+  availableBalance: 2750000, reservedBalance: 50000,
+  dailyLimit: 5000000, monthlyLimit: 20000000, dailySpending: 100000,
+  monthlySpending: 500000, maintenanceFee: 1500,
+  ownerName: 'Milica Nikolic',
+  firm: {
+    id: 1, companyName: 'TechStart DOO', registrationNumber: '20123456',
+    taxId: '101234567', activityCode: '62.01',
+  },
+};
+
+const MOCK_TRANSACTIONS = {
+  content: [
+    {
+      id: 1, fromAccountNumber: '265000000000000112', toAccountNumber: '265000000000000229',
+      amount: 15000, currency: 'RSD', description: 'Uplata', referenceNumber: 'REF001',
+      paymentCode: '289', paymentPurpose: 'Placanje racuna za struju',
+      recipientName: 'EPS Distribucija', status: 'COMPLETED', createdAt: '2025-03-10',
+    },
+    {
+      id: 2, fromAccountNumber: '265000000000000336', toAccountNumber: '265000000000000112',
+      amount: 50000, currency: 'RSD', description: 'Prenos', referenceNumber: 'REF002',
+      paymentCode: '289', paymentPurpose: 'Prenos sredstava',
+      recipientName: 'Milica Nikolic', status: 'PENDING', createdAt: '2025-03-09',
+    },
+  ],
+  totalElements: 2,
+  totalPages: 1,
+  size: 10,
+  number: 0,
+};
+
+const EMPTY_TRANSACTIONS = {
+  content: [], totalElements: 0, totalPages: 0, size: 10, number: 0,
+};
+
+function setupClientSession(win: Cypress.AUTWindow) {
+  win.sessionStorage.setItem('accessToken', 'fake-access-token');
+  win.sessionStorage.setItem('refreshToken', 'fake-refresh-token');
+  win.sessionStorage.setItem(
+    'user',
+    JSON.stringify({
+      id: 2, email: 'user@test.com', username: 'user',
+      firstName: 'Stefan', lastName: 'Jovanovic', permissions: ['VIEW_STOCKS'],
+    })
+  );
+}
+
+describe('AccountDetailsPage - Licni racun', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'http://localhost:8080/accounts/1', {
+      statusCode: 200,
+      body: MOCK_ACCOUNT,
+    }).as('getAccount');
+
+    cy.intercept('GET', 'http://localhost:8080/transactions*', {
+      statusCode: 200,
+      body: MOCK_TRANSACTIONS,
+    }).as('getTransactions');
+
+    cy.visit('/accounts/1', {
+      onBeforeLoad(win) { setupClientSession(win); },
+    });
+
+    cy.contains('Tekuci racun - RSD', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('prikazuje naziv racuna kao naslov', () => {
+    cy.contains('h1', 'Tekuci racun - RSD').should('be.visible');
+  });
+
+  it('prikazuje badge za status i tip', () => {
+    cy.contains('Aktivan').should('be.visible');
+    cy.contains('Tekuci').should('be.visible');
+  });
+
+  it('prikazuje formatiran broj racuna', () => {
+    cy.contains('265-').should('be.visible');
+  });
+
+  it('prikazuje dugme za nazad', () => {
+    cy.contains('Nazad na racune').should('be.visible');
+  });
+
+  describe('Stanje racuna', () => {
+    it('prikazuje karticu sa stanjem', () => {
+      cy.contains('Stanje racuna').should('be.visible');
+    });
+
+    it('prikazuje ukupno stanje', () => {
+      cy.contains('Ukupno stanje').should('be.visible');
+    });
+
+    it('prikazuje raspolozivo stanje', () => {
+      cy.contains('Raspolozivo').should('be.visible');
+    });
+
+    it('prikazuje rezervisano stanje', () => {
+      cy.contains('Rezervisano').should('be.visible');
+    });
+
+    it('prikazuje odrzavanje', () => {
+      cy.contains('Odrzavanje').should('be.visible');
+    });
+  });
+
+  describe('Limiti i potrosnja', () => {
+    it('prikazuje karticu sa limitima', () => {
+      cy.contains('Limiti i potrosnja').should('be.visible');
+    });
+
+    it('prikazuje dnevnu potrosnju', () => {
+      cy.contains('Dnevna potrosnja').should('be.visible');
+    });
+
+    it('prikazuje mesecnu potrosnju', () => {
+      cy.contains('Mesecna potrosnja').should('be.visible');
+    });
+
+    it('prikazuje progress barove', () => {
+      cy.get('[role="progressbar"]').should('have.length', 2);
+    });
+
+    it('prikazuje input za dnevni limit', () => {
+      cy.get('#dailyLimit').should('be.visible').and('have.value', '200000');
+    });
+
+    it('prikazuje input za mesecni limit', () => {
+      cy.get('#monthlyLimit').should('be.visible').and('have.value', '1000000');
+    });
+
+    it('prikazuje dugme za cuvanje limita', () => {
+      cy.contains('button', 'Sacuvaj limite').should('be.visible');
+    });
+
+    it('poziva API za promenu limita', () => {
+      cy.intercept('PATCH', 'http://localhost:8080/accounts/1/limit', {
+        statusCode: 200,
+        body: {},
+      }).as('changeLimits');
+
+      cy.get('#dailyLimit').clear().type('300000');
+      cy.contains('button', 'Sacuvaj limite').click();
+      cy.wait('@changeLimits');
+    });
+  });
+
+  describe('Akcije', () => {
+    it('prikazuje input za promenu naziva', () => {
+      cy.get('input[placeholder="Novi naziv racuna"]').should('be.visible');
+    });
+
+    it('prikazuje dugme za promenu naziva', () => {
+      cy.contains('button', 'Promeni naziv').should('be.visible');
+    });
+
+    it('poziva API za promenu naziva', () => {
+      cy.intercept('PATCH', 'http://localhost:8080/accounts/1/name', {
+        statusCode: 200,
+        body: { ...MOCK_ACCOUNT, name: 'Moj glavni racun' },
+      }).as('rename');
+
+      cy.get('input[placeholder="Novi naziv racuna"]').clear().type('Moj glavni racun');
+      cy.contains('button', 'Promeni naziv').click();
+      cy.wait('@rename');
+    });
+
+    it('prikazuje dugme za novo placanje', () => {
+      cy.contains('button', 'Novo placanje').should('be.visible');
+    });
+
+    it('prikazuje dugme za prenos', () => {
+      cy.contains('button', 'Prenos').should('be.visible');
+    });
+
+    it('prikazuje dugme za sve transakcije', () => {
+      cy.contains('button', 'Sve transakcije').should('be.visible');
+    });
+  });
+
+  describe('Poslednje transakcije', () => {
+    it('prikazuje karticu sa transakcijama', () => {
+      cy.contains('Poslednje transakcije').should('be.visible');
+    });
+
+    it('prikazuje tabelu transakcija', () => {
+      cy.get('table').should('be.visible');
+      cy.contains('th', 'Datum').should('be.visible');
+      cy.contains('th', 'Svrha').should('be.visible');
+      cy.contains('th', 'Iznos').should('be.visible');
+      cy.contains('th', 'Status').should('be.visible');
+    });
+
+    it('prikazuje transakcije u tabeli', () => {
+      cy.get('table tbody tr').should('have.length', 2);
+    });
+
+    it('prikazuje odlaznu transakciju crvenom bojom', () => {
+      cy.get('table tbody tr').first().within(() => {
+        cy.get('.text-destructive').should('exist');
+      });
+    });
+
+    it('prikazuje dolaznu transakciju zelenom bojom', () => {
+      cy.get('table tbody tr').eq(1).within(() => {
+        cy.get('.text-green-600').should('exist');
+      });
+    });
+
+    it('prikazuje status badge', () => {
+      cy.get('table').within(() => {
+        cy.contains('Zavrsena').should('exist');
+        cy.contains('Na cekanju').should('exist');
+      });
+    });
+
+    it('prikazuje poruku kada nema transakcija', () => {
+      cy.intercept('GET', 'http://localhost:8080/transactions*', {
+        statusCode: 200,
+        body: EMPTY_TRANSACTIONS,
+      }).as('getEmptyTransactions');
+
+      cy.visit('/accounts/1', {
+        onBeforeLoad(win) { setupClientSession(win); },
+      });
+
+      cy.contains('Nema transakcija za ovaj racun', { timeout: 10000 }).should('be.visible');
+    });
+  });
+
+  describe('Loading i greske', () => {
+    it('prikazuje spinner dok se ucitavaju podaci', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts/1', {
+        statusCode: 200,
+        body: MOCK_ACCOUNT,
+        delay: 1000,
+      }).as('getAccountSlow');
+
+      cy.visit('/accounts/1', {
+        onBeforeLoad(win) { setupClientSession(win); },
+      });
+
+      cy.get('.animate-spin').should('exist');
+    });
+
+    it('prikazuje poruku kada racun nije pronadjen', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts/999', {
+        statusCode: 404,
+        body: { message: 'Not Found' },
+      }).as('getAccountNotFound');
+
+      cy.visit('/accounts/999', {
+        onBeforeLoad(win) { setupClientSession(win); },
+      });
+
+      cy.contains('Racun nije pronadjen', { timeout: 10000 }).should('be.visible');
+    });
+  });
+});
+
+describe('BusinessAccountDetailsPage - Poslovni racun', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'http://localhost:8080/accounts/3', {
+      statusCode: 200,
+      body: MOCK_BUSINESS_ACCOUNT,
+    }).as('getBusinessAccount');
+
+    cy.intercept('GET', 'http://localhost:8080/accounts/3/business', {
+      statusCode: 200,
+      body: MOCK_BUSINESS_ACCOUNT,
+    }).as('getBusinessDetails');
+
+    cy.intercept('GET', 'http://localhost:8080/transactions*', {
+      statusCode: 200,
+      body: MOCK_TRANSACTIONS,
+    }).as('getTransactions');
+
+    cy.visit('/accounts/3/business', {
+      onBeforeLoad(win) { setupClientSession(win); },
+    });
+
+    cy.contains('Poslovni racun - RSD', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('prikazuje naziv racuna', () => {
+    cy.contains('h1', 'Poslovni racun - RSD').should('be.visible');
+  });
+
+  it('prikazuje badge za status i tip', () => {
+    cy.contains('Aktivan').should('be.visible');
+    cy.contains('Poslovni').should('be.visible');
+  });
+
+  describe('Informacije o firmi', () => {
+    it('prikazuje karticu sa informacijama o firmi', () => {
+      cy.contains('Informacije o firmi').should('be.visible');
+    });
+
+    it('prikazuje naziv firme', () => {
+      cy.contains('Naziv firme').should('be.visible');
+      cy.contains('TechStart DOO').should('be.visible');
+    });
+
+    it('prikazuje maticni broj', () => {
+      cy.contains('Maticni broj').should('be.visible');
+      cy.contains('20123456').should('be.visible');
+    });
+
+    it('prikazuje PIB', () => {
+      cy.contains('PIB').should('be.visible');
+      cy.contains('101234567').should('be.visible');
+    });
+
+    it('prikazuje sifru delatnosti', () => {
+      cy.contains('Sifra delatnosti').should('be.visible');
+      cy.contains('62.01').should('be.visible');
+    });
+  });
+
+  describe('Stanje racuna', () => {
+    it('prikazuje karticu sa stanjem', () => {
+      cy.contains('Stanje racuna').should('be.visible');
+    });
+
+    it('prikazuje ukupno stanje', () => {
+      cy.contains('Ukupno stanje').should('be.visible');
+    });
+  });
+
+  describe('Limiti i potrosnja', () => {
+    it('prikazuje karticu sa limitima', () => {
+      cy.contains('Limiti i potrosnja').should('be.visible');
+    });
+
+    it('prikazuje progress barove', () => {
+      cy.get('[role="progressbar"]').should('have.length', 2);
+    });
+
+    it('prikazuje dugme za cuvanje limita', () => {
+      cy.contains('button', 'Sacuvaj limite').should('be.visible');
+    });
+  });
+
+  describe('Akcije', () => {
+    it('prikazuje input za promenu naziva', () => {
+      cy.get('input[placeholder="Novi naziv racuna"]').should('be.visible');
+    });
+
+    it('prikazuje dugmad za placanje i prenos', () => {
+      cy.contains('button', 'Novo placanje').should('be.visible');
+      cy.contains('button', 'Prenos').should('be.visible');
+      cy.contains('button', 'Sve transakcije').should('be.visible');
+    });
+  });
+
+  describe('Poslednje transakcije', () => {
+    it('prikazuje karticu sa transakcijama', () => {
+      cy.contains('Poslednje transakcije').should('be.visible');
+    });
+
+    it('prikazuje tabelu transakcija', () => {
+      cy.get('table tbody tr').should('have.length', 2);
+    });
+  });
+});

--- a/src/pages/Accounts/AccountDetailsPage.tsx
+++ b/src/pages/Accounts/AccountDetailsPage.tsx
@@ -1,47 +1,80 @@
-// TODO [FE2-03a] @Jovan - Detaljan prikaz racuna - licni
-//
-// Ova stranica prikazuje detalje jednog racuna (tekuci ili devizni).
-// - useParams() za accountId iz URL-a
-// - accountService.getById(id) za fetch racuna
-// - transactionService.getAll({ accountNumber }) za poslednjih N transakcija
-// - Prikaz: naziv, broj, tip, podvrsta (accountSubtype), valuta, stanje, raspolozivo stanje,
-//   rezervisana sredstva, dnevni/mesecni limit, dnevna/mesecna potrosnja, status, datum kreiranja
-// - Lista poslednjih transakcija za ovaj racun
-// - Dugme za promenu naziva racuna (accountService.updateName, schema: accountRenameSchema)
-// - Dugme za promenu limita (accountService.changeLimit, schema: accountLimitSchema)
-//   => modal sa dnevni limit i mesecni limit, zahteva verifikaciju (VerificationModal)
+// FE2-03a: Detaljan prikaz licnog racuna (tekuci/devizni)
 
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  ArrowDownLeft,
+  Loader2,
+  Pencil,
+  CreditCard,
+  ArrowLeftRight,
+  History,
+} from 'lucide-react';
 import { toast } from '@/lib/notify';
 import { accountService } from '@/services/accountService';
 import { transactionService } from '@/services/transactionService';
 import type { Account, Transaction } from '@/types/celina2';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
-function statusClass(status: string): string {
-  if (status === 'ACTIVE') return 'bg-green-100 text-green-700';
-  if (status === 'BLOCKED') return 'bg-red-100 text-red-700';
-  return 'bg-muted text-muted-foreground';
+const accountTypeLabels: Record<string, string> = {
+  TEKUCI: 'Tekuci',
+  DEVIZNI: 'Devizni',
+  POSLOVNI: 'Poslovni',
+};
+
+const statusLabels: Record<string, string> = {
+  ACTIVE: 'Aktivan',
+  BLOCKED: 'Blokiran',
+  INACTIVE: 'Neaktivan',
+};
+
+const statusVariant: Record<string, 'success' | 'destructive' | 'secondary'> = {
+  ACTIVE: 'success',
+  BLOCKED: 'destructive',
+  INACTIVE: 'secondary',
+};
+
+const txStatusLabels: Record<string, string> = {
+  PENDING: 'Na cekanju',
+  COMPLETED: 'Zavrsena',
+  REJECTED: 'Odbijena',
+  CANCELLED: 'Otkazana',
+};
+
+const txStatusVariant: Record<string, 'warning' | 'success' | 'destructive' | 'secondary'> = {
+  PENDING: 'warning',
+  COMPLETED: 'success',
+  REJECTED: 'destructive',
+  CANCELLED: 'secondary',
+};
+
+function formatBalance(amount: number, currency: string): string {
+  return `${amount.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
 }
 
 function formatAccountNumber(accountNumber: string): string {
   if (accountNumber.length !== 18) return accountNumber;
-  return `${accountNumber.slice(0, 3)}-${accountNumber.slice(3, 7)}-${accountNumber.slice(7, 16)}-${accountNumber.slice(16)}`;
+  return `${accountNumber.slice(0, 3)}-${accountNumber.slice(3, 16)}-${accountNumber.slice(16)}`;
 }
 
-function formatAmount(value: number | null | undefined, decimals = 2): string {
-  const num = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(num) ? num.toFixed(decimals) : (0).toFixed(decimals);
-}
-
-function formatDateTime(value: string | null | undefined): string {
-  if (!value) return '-';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString('sr-RS');
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('sr-RS', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 export default function AccountDetailsPage() {
@@ -77,9 +110,9 @@ export default function AccountDetailsPage() {
           page: 0,
           limit: 10,
         });
-        setTransactions(transactionsResponse.content);
+        setTransactions(Array.isArray(transactionsResponse.content) ? transactionsResponse.content : []);
       } catch {
-        toast.error('Neuspešno učitavanje detalja računa.');
+        toast.error('Greska pri ucitavanju detalja racuna.');
       } finally {
         setLoading(false);
       }
@@ -102,7 +135,7 @@ export default function AccountDetailsPage() {
     if (!account) return;
     const newName = renameValue.trim();
     if (!newName) {
-      toast.error('Naziv računa ne sme biti prazan.');
+      toast.error('Naziv racuna ne sme biti prazan.');
       return;
     }
 
@@ -110,7 +143,7 @@ export default function AccountDetailsPage() {
     try {
       const updated = await accountService.updateName(account.id, newName);
       setAccount(updated);
-      toast.success('Naziv računa je uspešno promenjen.');
+      toast.success('Naziv racuna je uspesno promenjen.');
     } catch {
       toast.error('Promena naziva nije uspela.');
     } finally {
@@ -134,7 +167,7 @@ export default function AccountDetailsPage() {
         monthlyLimit: parsedMonthly,
       });
       setAccount({ ...account, dailyLimit: parsedDaily, monthlyLimit: parsedMonthly });
-      toast.success('Limiti su uspešno sačuvani.');
+      toast.success('Limiti su uspesno sacuvani.');
     } catch {
       toast.error('Promena limita nije uspela.');
     } finally {
@@ -142,127 +175,203 @@ export default function AccountDetailsPage() {
     }
   };
 
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!account) {
+    return (
+      <div className="container mx-auto py-6 space-y-4">
+        <Button variant="ghost" onClick={() => navigate('/accounts')}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na racune
+        </Button>
+        <p className="text-muted-foreground">Racun nije pronadjen.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="container mx-auto py-6 space-y-6">
-      {loading || !account ? (
-        <p className="text-muted-foreground">Učitavanje detalja računa...</p>
-      ) : (
-        <>
-          <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-3xl font-bold">{account.name || 'Detalji računa'}</h1>
-            <span className={`px-2 py-1 rounded text-xs font-medium ${statusClass(account.status)}`}>{account.status}</span>
-            <span className="px-2 py-1 rounded text-xs bg-muted">{account.accountType}</span>
+    <div className="space-y-6">
+      {/* Back button */}
+      <Button variant="ghost" size="sm" onClick={() => navigate('/accounts')}>
+        <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na racune
+      </Button>
+
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-3xl font-bold">{account.name || 'Detalji racuna'}</h1>
+        <Badge variant={statusVariant[account.status]}>
+          {statusLabels[account.status] || account.status}
+        </Badge>
+        <Badge variant="info">
+          {accountTypeLabels[account.accountType] || account.accountType}
+        </Badge>
+      </div>
+      <p className="text-muted-foreground">{formatAccountNumber(account.accountNumber)}</p>
+
+      {/* Balance card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Stanje racuna</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Ukupno stanje</p>
+              <p className="text-xl font-semibold">{formatBalance(account.balance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Raspolozivo</p>
+              <p className="text-xl font-semibold">{formatBalance(account.availableBalance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Rezervisano</p>
+              <p className="text-lg font-medium text-muted-foreground">{formatBalance(account.reservedBalance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Odrzavanje</p>
+              <p className="text-lg font-medium text-muted-foreground">{formatBalance(account.maintenanceFee, account.currency)}</p>
+            </div>
           </div>
-          <p className="text-muted-foreground">{formatAccountNumber(account.accountNumber)}</p>
+        </CardContent>
+      </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Stanje računa</CardTitle>
-            </CardHeader>
-            <CardContent className="grid gap-2 md:grid-cols-2 text-sm">
-              <p>Stanje: <span className="font-medium">{formatAmount(account.balance)} {account.currency}</span></p>
-              <p>Raspoloživo: <span className="font-medium">{formatAmount(account.availableBalance)} {account.currency}</span></p>
-              <p>Rezervisano: <span className="font-medium">{formatAmount(account.reservedBalance)} {account.currency}</span></p>
-              <p>Podvrsta: <span className="font-medium">{account.accountSubtype || '-'}</span></p>
-            </CardContent>
-          </Card>
+      {/* Limits card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Limiti i potrosnja</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <span>Dnevna potrosnja</span>
+              <span className="font-medium">
+                {formatBalance(account.dailySpending, account.currency)} / {formatBalance(account.dailyLimit, account.currency)}
+              </span>
+            </div>
+            <Progress value={dailyProgress} className="h-2" />
+          </div>
+          <div className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <span>Mesecna potrosnja</span>
+              <span className="font-medium">
+                {formatBalance(account.monthlySpending, account.currency)} / {formatBalance(account.monthlyLimit, account.currency)}
+              </span>
+            </div>
+            <Progress value={monthlyProgress} className="h-2" />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="dailyLimit">Novi dnevni limit</Label>
+              <Input id="dailyLimit" type="number" value={dailyLimit} onChange={(e) => setDailyLimit(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="monthlyLimit">Novi mesecni limit</Label>
+              <Input id="monthlyLimit" type="number" value={monthlyLimit} onChange={(e) => setMonthlyLimit(e.target.value)} />
+            </div>
+          </div>
+          <Button onClick={saveLimits} disabled={isSavingLimits}>
+            {isSavingLimits ? 'Cuvanje...' : 'Sacuvaj limite'}
+          </Button>
+        </CardContent>
+      </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Limiti i potrošnja</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm">
-              <div>
-                <p>Dnevni limit / potrošnja: {formatAmount(account.dailyLimit)} / {formatAmount(account.dailySpending)} {account.currency}</p>
-                <progress className="w-full h-2" max={100} value={dailyProgress} />
-              </div>
-              <div>
-                <p>Mesečni limit / potrošnja: {formatAmount(account.monthlyLimit)} / {formatAmount(account.monthlySpending)} {account.currency}</p>
-                <progress className="w-full h-2" max={100} value={monthlyProgress} />
-              </div>
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="dailyLimit">Novi dnevni limit</Label>
-                  <Input id="dailyLimit" type="number" value={dailyLimit} onChange={(e) => setDailyLimit(e.target.value)} />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="monthlyLimit">Novi mesečni limit</Label>
-                  <Input id="monthlyLimit" type="number" value={monthlyLimit} onChange={(e) => setMonthlyLimit(e.target.value)} />
-                </div>
-              </div>
-              <Button onClick={saveLimits} disabled={isSavingLimits}>
-                {isSavingLimits ? 'Čuvanje...' : 'Sačuvaj limite'}
-              </Button>
-            </CardContent>
-          </Card>
+      {/* Actions card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Akcije</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Pencil className="h-4 w-4 text-muted-foreground" />
+            <Input
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              placeholder="Novi naziv racuna"
+              className="max-w-sm"
+            />
+            <Button onClick={saveName} disabled={isSavingName}>
+              {isSavingName ? 'Cuvanje...' : 'Promeni naziv'}
+            </Button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => navigate(`/payments/new?from=${account.accountNumber}`)}>
+              <CreditCard className="mr-2 h-4 w-4" /> Novo placanje
+            </Button>
+            <Button variant="outline" onClick={() => navigate(`/transfers?from=${account.accountNumber}`)}>
+              <ArrowLeftRight className="mr-2 h-4 w-4" /> Prenos
+            </Button>
+            <Button variant="outline" onClick={() => navigate(`/payments/history?account=${account.accountNumber}`)}>
+              <History className="mr-2 h-4 w-4" /> Sve transakcije
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Akcije</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid gap-2 md:grid-cols-[1fr_auto]">
-                <Input value={renameValue} onChange={(e) => setRenameValue(e.target.value)} placeholder="Novi naziv računa" />
-                <Button onClick={saveName} disabled={isSavingName}>{isSavingName ? 'Čuvanje...' : 'Promeni naziv'}</Button>
-              </div>
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={() => navigate(`/payments/new?from=${account.accountNumber}`)}>
-                  Novo plaćanje
-                </Button>
-                <Button variant="outline" onClick={() => navigate(`/transfers?from=${account.accountNumber}`)}>
-                  Prenos
-                </Button>
-                <Button variant="outline" onClick={() => navigate(`/payments/history?account=${account.accountNumber}`)}>
-                  Vidi sve transakcije
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Poslednje transakcije</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {transactions.length === 0 ? (
-                <p className="text-muted-foreground">Nema transakcija za ovaj račun.</p>
-              ) : (
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="border-b">
-                        <th className="text-left py-2">Datum</th>
-                        <th className="text-left py-2">Opis</th>
-                        <th className="text-left py-2">Primalac/pošiljalac</th>
-                        <th className="text-left py-2">Iznos</th>
-                        <th className="text-left py-2">Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {transactions.map((transaction) => {
-                        const counterparty =
-                          transaction.fromAccountNumber === account.accountNumber
-                            ? transaction.toAccountNumber
-                            : transaction.fromAccountNumber;
-                        return (
-                          <tr key={transaction.id} className="border-b">
-                            <td className="py-2">{formatDateTime(transaction.createdAt)}</td>
-                            <td className="py-2">{transaction.description || transaction.paymentPurpose}</td>
-                            <td className="py-2">{counterparty}</td>
-                            <td className="py-2">{formatAmount(transaction.amount)} {transaction.currency}</td>
-                            <td className="py-2">{transaction.status}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </>
-      )}
+      {/* Recent transactions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Poslednje transakcije</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {transactions.length === 0 ? (
+            <p className="text-center py-8 text-muted-foreground">Nema transakcija za ovaj racun.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[40px]"></TableHead>
+                  <TableHead>Datum</TableHead>
+                  <TableHead>Primalac / Posiljalac</TableHead>
+                  <TableHead>Svrha</TableHead>
+                  <TableHead className="text-right">Iznos</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {transactions.map((tx) => {
+                  const isOutgoing = tx.fromAccountNumber === account.accountNumber;
+                  return (
+                    <TableRow key={tx.id}>
+                      <TableCell>
+                        {isOutgoing ? (
+                          <ArrowUpRight className="h-4 w-4 text-destructive" />
+                        ) : (
+                          <ArrowDownLeft className="h-4 w-4 text-green-600" />
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">{formatDate(tx.createdAt)}</TableCell>
+                      <TableCell>
+                        {tx.recipientName || '—'}
+                        <span className="block text-xs text-muted-foreground">
+                          {isOutgoing
+                            ? formatAccountNumber(tx.toAccountNumber)
+                            : formatAccountNumber(tx.fromAccountNumber)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="max-w-[200px] truncate" title={tx.paymentPurpose}>
+                        {tx.paymentPurpose}
+                      </TableCell>
+                      <TableCell className={`text-right font-medium whitespace-nowrap ${isOutgoing ? 'text-destructive' : 'text-green-600'}`}>
+                        {isOutgoing ? '−' : '+'}{formatBalance(tx.amount, tx.currency)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={txStatusVariant[tx.status]}>
+                          {txStatusLabels[tx.status] || tx.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
-

--- a/src/pages/Accounts/BusinessAccountDetailsPage.tsx
+++ b/src/pages/Accounts/BusinessAccountDetailsPage.tsx
@@ -1,170 +1,406 @@
-// TODO [FE2-03a] @Jovan - Racuni: Detalji poslovnog racuna (osnovni prikaz)
-//
-// Ova stranica prikazuje detalje poslovnog racuna sa dodatnim info o firmi.
-// - useParams() za accountId iz URL-a
-// - accountService.getById(id) + accountService.getBusinessDetails(id)
-// - Sve sto ima AccountDetailsPage PLUS:
-//   - Naziv firme (companyName)
-//   - Maticni broj (registrationNumber)
-//   - PIB (taxId)
-//   - Sifra delatnosti (activityCode)
+// FE2-03a: Detaljan prikaz poslovnog racuna (sa informacijama o firmi)
 
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  ArrowDownLeft,
+  Loader2,
+  Pencil,
+  CreditCard,
+  ArrowLeftRight,
+  History,
+  Building2,
+} from 'lucide-react';
 import { toast } from '@/lib/notify';
 import { accountService } from '@/services/accountService';
 import { transactionService } from '@/services/transactionService';
 import type { Account, BusinessAccount, Transaction } from '@/types/celina2';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
-function formatAmount(value: number | null | undefined, decimals = 2): string {
-  const num = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(num) ? num.toFixed(decimals) : (0).toFixed(decimals);
+const statusLabels: Record<string, string> = {
+  ACTIVE: 'Aktivan',
+  BLOCKED: 'Blokiran',
+  INACTIVE: 'Neaktivan',
+};
+
+const statusVariant: Record<string, 'success' | 'destructive' | 'secondary'> = {
+  ACTIVE: 'success',
+  BLOCKED: 'destructive',
+  INACTIVE: 'secondary',
+};
+
+const txStatusLabels: Record<string, string> = {
+  PENDING: 'Na cekanju',
+  COMPLETED: 'Zavrsena',
+  REJECTED: 'Odbijena',
+  CANCELLED: 'Otkazana',
+};
+
+const txStatusVariant: Record<string, 'warning' | 'success' | 'destructive' | 'secondary'> = {
+  PENDING: 'warning',
+  COMPLETED: 'success',
+  REJECTED: 'destructive',
+  CANCELLED: 'secondary',
+};
+
+function formatBalance(amount: number, currency: string): string {
+  return `${amount.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
 }
 
-function formatDateTime(value: string | null | undefined): string {
-  if (!value) return '-';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString('sr-RS');
+function formatAccountNumber(accountNumber: string): string {
+  if (accountNumber.length !== 18) return accountNumber;
+  return `${accountNumber.slice(0, 3)}-${accountNumber.slice(3, 16)}-${accountNumber.slice(16)}`;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('sr-RS', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 export default function BusinessAccountDetailsPage() {
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const [account, setAccount] = useState<Account | null>(null);
   const [businessDetails, setBusinessDetails] = useState<BusinessAccount | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [isLoadingBusiness, setIsLoadingBusiness] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [renameValue, setRenameValue] = useState('');
+  const [dailyLimit, setDailyLimit] = useState('');
+  const [monthlyLimit, setMonthlyLimit] = useState('');
+  const [isSavingName, setIsSavingName] = useState(false);
+  const [isSavingLimits, setIsSavingLimits] = useState(false);
 
   useEffect(() => {
     const accountId = Number(id);
     if (!accountId || Number.isNaN(accountId)) {
-      setIsLoadingBusiness(false);
+      setLoading(false);
       return;
     }
 
-    const loadBusinessDetails = async () => {
-      setIsLoadingBusiness(true);
+    const loadData = async () => {
+      setLoading(true);
       try {
-        const [accountDetails, details] = await Promise.all([
+        const [accountData, details] = await Promise.all([
           accountService.getById(accountId),
           accountService.getBusinessDetails(accountId),
         ]);
-        setAccount(accountDetails);
+        setAccount(accountData);
         setBusinessDetails(details);
+        setRenameValue(accountData.name || '');
+        setDailyLimit(String(accountData.dailyLimit));
+        setMonthlyLimit(String(accountData.monthlyLimit));
 
-        const recentTransactions = await transactionService.getAll({
-          accountNumber: accountDetails.accountNumber,
+        const transactionsResponse = await transactionService.getAll({
+          accountNumber: accountData.accountNumber,
           page: 0,
           limit: 10,
         });
-        setTransactions(recentTransactions.content);
+        setTransactions(Array.isArray(transactionsResponse.content) ? transactionsResponse.content : []);
       } catch {
-        toast.error('Neuspešno učitavanje informacija o firmi.');
+        toast.error('Greska pri ucitavanju detalja racuna.');
       } finally {
-        setIsLoadingBusiness(false);
+        setLoading(false);
       }
     };
 
-    loadBusinessDetails();
+    loadData();
   }, [id]);
 
-  // TODO [FE2-03a] @Jovan - Fetch racun i business detalje
-  // accountService.getById(Number(id))
-  // accountService.getBusinessDetails(Number(id))
-  // transactionService.getAll({ accountNumber: account.accountNumber, limit: 10 })
+  const dailyProgress = useMemo(() => {
+    if (!account || account.dailyLimit <= 0) return 0;
+    return Math.min(100, (account.dailySpending / account.dailyLimit) * 100);
+  }, [account]);
+
+  const monthlyProgress = useMemo(() => {
+    if (!account || account.monthlyLimit <= 0) return 0;
+    return Math.min(100, (account.monthlySpending / account.monthlyLimit) * 100);
+  }, [account]);
+
+  const saveName = async () => {
+    if (!account) return;
+    const newName = renameValue.trim();
+    if (!newName) {
+      toast.error('Naziv racuna ne sme biti prazan.');
+      return;
+    }
+
+    setIsSavingName(true);
+    try {
+      const updated = await accountService.updateName(account.id, newName);
+      setAccount(updated);
+      toast.success('Naziv racuna je uspesno promenjen.');
+    } catch {
+      toast.error('Promena naziva nije uspela.');
+    } finally {
+      setIsSavingName(false);
+    }
+  };
+
+  const saveLimits = async () => {
+    if (!account) return;
+    const parsedDaily = Number(dailyLimit);
+    const parsedMonthly = Number(monthlyLimit);
+    if (Number.isNaN(parsedDaily) || Number.isNaN(parsedMonthly) || parsedDaily < 0 || parsedMonthly < 0) {
+      toast.error('Limiti moraju biti nenegativni brojevi.');
+      return;
+    }
+
+    setIsSavingLimits(true);
+    try {
+      await accountService.changeLimit(account.id, {
+        dailyLimit: parsedDaily,
+        monthlyLimit: parsedMonthly,
+      });
+      setAccount({ ...account, dailyLimit: parsedDaily, monthlyLimit: parsedMonthly });
+      toast.success('Limiti su uspesno sacuvani.');
+    } catch {
+      toast.error('Promena limita nije uspela.');
+    } finally {
+      setIsSavingLimits(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!account) {
+    return (
+      <div className="container mx-auto py-6 space-y-4">
+        <Button variant="ghost" onClick={() => navigate('/accounts')}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na racune
+        </Button>
+        <p className="text-muted-foreground">Racun nije pronadjen.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="container mx-auto py-6 space-y-6">
-      {/* TODO [FE2-03a] @Jovan - Header sa info o racunu (isto kao AccountDetailsPage)
-          - Naziv racuna, broj, tip=POSLOVNI badge, status badge */}
-      <div className="space-y-1">
-        <h1 className="text-3xl font-bold">{account?.name || 'Poslovni račun'}</h1>
-        <p className="text-muted-foreground">ID: {id}</p>
-        {account && (
-          <p className="text-muted-foreground">
-            {account.accountNumber} | {account.status}
-          </p>
-        )}
+    <div className="space-y-6">
+      {/* Back button */}
+      <Button variant="ghost" size="sm" onClick={() => navigate('/accounts')}>
+        <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na racune
+      </Button>
+
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-3xl font-bold">{account.name || 'Poslovni racun'}</h1>
+        <Badge variant={statusVariant[account.status]}>
+          {statusLabels[account.status] || account.status}
+        </Badge>
+        <Badge variant="warning">Poslovni</Badge>
       </div>
+      <p className="text-muted-foreground">{formatAccountNumber(account.accountNumber)}</p>
 
-      {/* TODO [FE2-03a] @Jovan - Kartica sa stanjem (isto kao AccountDetailsPage) */}
-      <section>
-        {!account ? (
-          <p className="text-muted-foreground">Učitavanje stanja...</p>
-        ) : (
-          <div className="grid gap-3 md:grid-cols-2 text-sm border rounded-md p-4 bg-card">
-            <p>
-              Stanje: <span className="font-medium">{formatAmount(account.balance)} {account.currency}</span>
-            </p>
-            <p>
-              Raspoloživo: <span className="font-medium">{formatAmount(account.availableBalance)} {account.currency}</span>
-            </p>
-            <p>
-              Rezervisano: <span className="font-medium">{formatAmount(account.reservedBalance)} {account.currency}</span>
-            </p>
-            <p>
-              Podvrsta: <span className="font-medium">{account.accountSubtype || '-'}</span>
-            </p>
-          </div>
-        )}
-      </section>
+      {/* Firm info card */}
+      {businessDetails?.firm && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Building2 className="h-5 w-5" /> Informacije o firmi
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <p className="text-sm text-muted-foreground">Naziv firme</p>
+                <p className="font-medium">{businessDetails.firm.companyName}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Maticni broj</p>
+                <p className="font-medium">{businessDetails.firm.registrationNumber}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">PIB</p>
+                <p className="font-medium">{businessDetails.firm.taxId}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Sifra delatnosti</p>
+                <p className="font-medium">{businessDetails.firm.activityCode}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-      <section>
-        <h2 className="text-xl font-semibold mb-4">Informacije o firmi</h2>
-        {isLoadingBusiness ? (
-          <p className="text-muted-foreground">Učitavanje podataka firme...</p>
-        ) : !businessDetails?.firm ? (
-          <p className="text-muted-foreground">Podaci o firmi nisu dostupni.</p>
-        ) : (
-          <div className="grid gap-3 md:grid-cols-2 text-sm border rounded-md p-4 bg-card">
-            <p>
-              Naziv firme: <span className="font-medium">{businessDetails.firm.companyName}</span>
-            </p>
-            <p>
-              Matični broj: <span className="font-medium">{businessDetails.firm.registrationNumber}</span>
-            </p>
-            <p>
-              PIB: <span className="font-medium">{businessDetails.firm.taxId}</span>
-            </p>
-            <p>
-              Šifra delatnosti: <span className="font-medium">{businessDetails.firm.activityCode}</span>
-            </p>
+      {/* Balance card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Stanje racuna</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Ukupno stanje</p>
+              <p className="text-xl font-semibold">{formatBalance(account.balance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Raspolozivo</p>
+              <p className="text-xl font-semibold">{formatBalance(account.availableBalance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Rezervisano</p>
+              <p className="text-lg font-medium text-muted-foreground">{formatBalance(account.reservedBalance, account.currency)}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Odrzavanje</p>
+              <p className="text-lg font-medium text-muted-foreground">{formatBalance(account.maintenanceFee, account.currency)}</p>
+            </div>
           </div>
-        )}
-      </section>
+        </CardContent>
+      </Card>
 
-      {/* TODO [FE2-03a] @Jovan - Akcije i transakcije (isto kao AccountDetailsPage) */}
-      <section>
-        <h2 className="text-xl font-semibold mb-4">Poslednje transakcije</h2>
-        {transactions.length === 0 ? (
-          <p className="text-muted-foreground">Nema transakcija za ovaj račun.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b">
-                  <th className="text-left py-2">Datum</th>
-                  <th className="text-left py-2">Opis</th>
-                  <th className="text-left py-2">Iznos</th>
-                  <th className="text-left py-2">Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {transactions.map((tx) => (
-                  <tr key={tx.id} className="border-b">
-                    <td className="py-2">{formatDateTime(tx.createdAt)}</td>
-                    <td className="py-2">{tx.description || tx.paymentPurpose}</td>
-                    <td className="py-2">{formatAmount(tx.amount)} {tx.currency}</td>
-                    <td className="py-2">{tx.status}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      {/* Limits card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Limiti i potrosnja</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <span>Dnevna potrosnja</span>
+              <span className="font-medium">
+                {formatBalance(account.dailySpending, account.currency)} / {formatBalance(account.dailyLimit, account.currency)}
+              </span>
+            </div>
+            <Progress value={dailyProgress} className="h-2" />
           </div>
-        )}
-      </section>
+          <div className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <span>Mesecna potrosnja</span>
+              <span className="font-medium">
+                {formatBalance(account.monthlySpending, account.currency)} / {formatBalance(account.monthlyLimit, account.currency)}
+              </span>
+            </div>
+            <Progress value={monthlyProgress} className="h-2" />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="dailyLimit">Novi dnevni limit</Label>
+              <Input id="dailyLimit" type="number" value={dailyLimit} onChange={(e) => setDailyLimit(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="monthlyLimit">Novi mesecni limit</Label>
+              <Input id="monthlyLimit" type="number" value={monthlyLimit} onChange={(e) => setMonthlyLimit(e.target.value)} />
+            </div>
+          </div>
+          <Button onClick={saveLimits} disabled={isSavingLimits}>
+            {isSavingLimits ? 'Cuvanje...' : 'Sacuvaj limite'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Actions card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Akcije</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Pencil className="h-4 w-4 text-muted-foreground" />
+            <Input
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              placeholder="Novi naziv racuna"
+              className="max-w-sm"
+            />
+            <Button onClick={saveName} disabled={isSavingName}>
+              {isSavingName ? 'Cuvanje...' : 'Promeni naziv'}
+            </Button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => navigate(`/payments/new?from=${account.accountNumber}`)}>
+              <CreditCard className="mr-2 h-4 w-4" /> Novo placanje
+            </Button>
+            <Button variant="outline" onClick={() => navigate(`/transfers?from=${account.accountNumber}`)}>
+              <ArrowLeftRight className="mr-2 h-4 w-4" /> Prenos
+            </Button>
+            <Button variant="outline" onClick={() => navigate(`/payments/history?account=${account.accountNumber}`)}>
+              <History className="mr-2 h-4 w-4" /> Sve transakcije
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Recent transactions */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Poslednje transakcije</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {transactions.length === 0 ? (
+            <p className="text-center py-8 text-muted-foreground">Nema transakcija za ovaj racun.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[40px]"></TableHead>
+                  <TableHead>Datum</TableHead>
+                  <TableHead>Primalac / Posiljalac</TableHead>
+                  <TableHead>Svrha</TableHead>
+                  <TableHead className="text-right">Iznos</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {transactions.map((tx) => {
+                  const isOutgoing = tx.fromAccountNumber === account.accountNumber;
+                  return (
+                    <TableRow key={tx.id}>
+                      <TableCell>
+                        {isOutgoing ? (
+                          <ArrowUpRight className="h-4 w-4 text-destructive" />
+                        ) : (
+                          <ArrowDownLeft className="h-4 w-4 text-green-600" />
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">{formatDate(tx.createdAt)}</TableCell>
+                      <TableCell>
+                        {tx.recipientName || '—'}
+                        <span className="block text-xs text-muted-foreground">
+                          {isOutgoing
+                            ? formatAccountNumber(tx.toAccountNumber)
+                            : formatAccountNumber(tx.fromAccountNumber)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="max-w-[200px] truncate" title={tx.paymentPurpose}>
+                        {tx.paymentPurpose}
+                      </TableCell>
+                      <TableCell className={`text-right font-medium whitespace-nowrap ${isOutgoing ? 'text-destructive' : 'text-green-600'}`}>
+                        {isOutgoing ? '−' : '+'}{formatBalance(tx.amount, tx.currency)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={txStatusVariant[tx.status]}>
+                          {txStatusLabels[tx.status] || tx.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
-
-
-


### PR DESCRIPTION
## Summary
- Polished AccountDetailsPage and BusinessAccountDetailsPage with consistent UI
- Badge components for status/type, sr-RS formatting, Progress bars for limits
- BusinessAccountDetailsPage now has full feature parity: rename, limits, action buttons
- Firm info card with company name, registration number, PIB, activity code
- Back navigation, loading spinner, not-found state

## Note
API endpoints use placeholder URLs (FIXME in services). Update when backend confirms actual endpoints.

## Test plan
- [x] E2E tests pass (`cypress/e2e/account-details.cy.ts`)
- [x] ESLint passes
- [x] Production build passes
- [ ] Verify with real backend once endpoints are ready

Closes #28