### PR TITLE
feat: [FE2-14a] polish employee accounts portal with filters and pagination

### DIFF
--- a/cypress/e2e/employee-accounts-portal.cy.ts
+++ b/cypress/e2e/employee-accounts-portal.cy.ts
@@ -1,0 +1,250 @@
+/// <reference types="cypress" />
+
+const MOCK_ACCOUNTS_PAGE = {
+  content: [
+    {
+      id: 1, accountNumber: '265000000000000112', name: 'Tekuci racun - RSD',
+      accountType: 'TEKUCI', status: 'ACTIVE', balance: 500000, availableBalance: 485230.5,
+      reservedBalance: 14769.5, dailyLimit: 200000, monthlyLimit: 1000000,
+      dailySpending: 0, monthlySpending: 15000, maintenanceFee: 250,
+      currency: 'RSD', ownerName: 'Stefan Jovanovic', createdAt: '2025-01-15',
+    },
+    {
+      id: 2, accountNumber: '265000000000000229', name: 'Devizni racun - EUR',
+      accountType: 'DEVIZNI', status: 'ACTIVE', balance: 13000, availableBalance: 12500.0,
+      reservedBalance: 500, dailyLimit: 50000, monthlyLimit: 200000,
+      dailySpending: 0, monthlySpending: 0, maintenanceFee: 3,
+      currency: 'EUR', ownerName: 'Stefan Jovanovic', createdAt: '2025-02-01',
+    },
+    {
+      id: 3, accountNumber: '265000000000000336', name: 'Poslovni racun - RSD',
+      accountType: 'POSLOVNI', status: 'BLOCKED', balance: 2800000, availableBalance: 2750000.0,
+      reservedBalance: 50000, dailyLimit: 5000000, monthlyLimit: 20000000,
+      dailySpending: 0, monthlySpending: 100000, maintenanceFee: 1500,
+      currency: 'RSD', ownerName: 'Milica Nikolic', createdAt: '2025-01-20',
+    },
+    {
+      id: 4, accountNumber: '265000000000000443', name: 'Tekuci racun - EUR',
+      accountType: 'TEKUCI', status: 'INACTIVE', balance: 0, availableBalance: 0,
+      reservedBalance: 0, dailyLimit: 0, monthlyLimit: 0,
+      dailySpending: 0, monthlySpending: 0, maintenanceFee: 0,
+      currency: 'EUR', ownerName: 'Ana Markovic', createdAt: '2025-03-01',
+    },
+  ],
+  totalElements: 4,
+  totalPages: 1,
+  size: 10,
+  number: 0,
+};
+
+function setupEmployeeSession(win: Cypress.AUTWindow) {
+  win.sessionStorage.setItem('accessToken', 'fake-access-token');
+  win.sessionStorage.setItem('refreshToken', 'fake-refresh-token');
+  win.sessionStorage.setItem(
+    'user',
+    JSON.stringify({
+      id: 1, email: 'admin@test.com', username: 'admin',
+      firstName: 'Admin', lastName: 'User',
+      permissions: ['ADMIN'],
+    })
+  );
+}
+
+function interceptAccountsApi(response = MOCK_ACCOUNTS_PAGE) {
+  cy.intercept('GET', 'http://localhost:8080/accounts*', {
+    statusCode: 200,
+    body: response,
+  }).as('getAccounts');
+}
+
+describe('Employee Accounts Portal', () => {
+  beforeEach(() => {
+    interceptAccountsApi();
+
+    cy.visit('/employee/accounts', {
+      onBeforeLoad(win) { setupEmployeeSession(win); },
+    });
+
+    cy.contains('Portal racuna', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('prikazuje naslov stranice', () => {
+    cy.contains('h1', 'Portal racuna').should('be.visible');
+  });
+
+  it('prikazuje dugme za kreiranje racuna', () => {
+    cy.contains('button', 'Kreiraj racun').should('be.visible');
+  });
+
+  it('prikazuje tabelu sa racunima', () => {
+    cy.get('table').should('be.visible');
+    cy.contains('th', 'Vlasnik').should('be.visible');
+    cy.contains('th', 'Broj racuna').should('be.visible');
+    cy.contains('th', 'Tip').should('be.visible');
+    cy.contains('th', 'Stanje').should('be.visible');
+    cy.contains('th', 'Status').should('be.visible');
+    cy.contains('th', 'Akcije').should('be.visible');
+  });
+
+  it('prikazuje racune u tabeli', () => {
+    cy.get('table tbody tr').should('have.length', 4);
+  });
+
+  it('prikazuje ime vlasnika', () => {
+    cy.get('table').within(() => {
+      cy.contains('Stefan Jovanovic').should('exist');
+      cy.contains('Milica Nikolic').should('exist');
+      cy.contains('Ana Markovic').should('exist');
+    });
+  });
+
+  it('prikazuje formatiran broj racuna', () => {
+    cy.contains('265-').should('be.visible');
+  });
+
+  it('prikazuje badge za tip racuna', () => {
+    cy.get('table').within(() => {
+      cy.contains('Tekuci').should('exist');
+      cy.contains('Devizni').should('exist');
+      cy.contains('Poslovni').should('exist');
+    });
+  });
+
+  it('prikazuje badge za status', () => {
+    cy.get('table').within(() => {
+      cy.contains('Aktivan').should('exist');
+      cy.contains('Blokiran').should('exist');
+      cy.contains('Neaktivan').should('exist');
+    });
+  });
+
+  it('prikazuje stanje formatirano u sr-RS formatu', () => {
+    cy.get('table tbody tr').first().find('td').eq(3).invoke('text')
+      .should('match', /\d{1,3}(\.\d{3})*(,\d{2})/);
+  });
+
+  describe('Akcije po racunu', () => {
+    it('prikazuje dugme Blokiraj za aktivan racun', () => {
+      cy.get('table tbody tr').first().within(() => {
+        cy.contains('button', 'Blokiraj').should('exist');
+      });
+    });
+
+    it('prikazuje dugme Aktiviraj za blokiran racun', () => {
+      cy.get('table tbody tr').eq(2).within(() => {
+        cy.contains('button', 'Aktiviraj').should('exist');
+      });
+    });
+
+    it('ne prikazuje dugme Deaktiviraj za neaktivan racun', () => {
+      cy.get('table tbody tr').eq(3).within(() => {
+        cy.contains('button', 'Deaktiviraj').should('not.exist');
+      });
+    });
+
+    it('prikazuje dugme za kartice', () => {
+      cy.get('table tbody tr').first().within(() => {
+        cy.get('button[title="Kartice"]').should('exist');
+      });
+    });
+
+    it('prikazuje dugme Detalji', () => {
+      cy.get('table tbody tr').first().within(() => {
+        cy.contains('button', 'Detalji').should('exist');
+      });
+    });
+
+    it('poziva API za promenu statusa', () => {
+      cy.intercept('PATCH', 'http://localhost:8080/accounts/1/status*', {
+        statusCode: 200,
+        body: {},
+      }).as('changeStatus');
+
+      cy.get('table tbody tr').first().within(() => {
+        cy.contains('button', 'Blokiraj').click();
+      });
+
+      cy.wait('@changeStatus');
+    });
+  });
+
+  describe('Filteri', () => {
+    beforeEach(() => {
+      cy.get('button[title="Filteri"]').click();
+    });
+
+    it('prikazuje filter sekciju', () => {
+      cy.contains('Email vlasnika').should('be.visible');
+      cy.contains('Tip racuna').should('be.visible');
+      cy.contains('Status').should('be.visible');
+    });
+
+    it('prikazuje input za email pretrazivanje', () => {
+      cy.get('input[placeholder="Pretrazi po emailu..."]').should('be.visible');
+    });
+
+    it('prikazuje select za tip racuna', () => {
+      cy.contains('Svi tipovi').should('be.visible');
+    });
+
+    it('prikazuje select za status', () => {
+      cy.contains('Svi statusi').should('be.visible');
+    });
+  });
+
+  describe('Paginacija', () => {
+    it('prikazuje informaciju o broju rezultata', () => {
+      cy.contains(/\d+–\d+ od \d+/).should('be.visible');
+    });
+
+    it('prikazuje informaciju o stranici', () => {
+      cy.contains(/Strana \d+ \/ \d+/).should('be.visible');
+    });
+
+    it('dugme za prethodnu stranicu je onemoguceno na prvoj stranici', () => {
+      cy.get('button:has(svg.lucide-chevron-left)').should('be.disabled');
+    });
+  });
+
+  describe('Loading i greske', () => {
+    it('prikazuje spinner dok se ucitavaju podaci', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts*', {
+        statusCode: 200,
+        body: MOCK_ACCOUNTS_PAGE,
+        delay: 1000,
+      }).as('getAccountsSlow');
+
+      cy.visit('/employee/accounts', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.get('.animate-spin').should('exist');
+    });
+
+    it('prikazuje poruku greske kada API vrati gresku', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts*', {
+        statusCode: 500,
+        body: { message: 'Internal Server Error' },
+      }).as('getAccountsError');
+
+      cy.visit('/employee/accounts', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.contains('Greska pri ucitavanju racuna', { timeout: 10000 }).should('be.visible');
+    });
+
+    it('prikazuje poruku kada nema racuna', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts*', {
+        statusCode: 200,
+        body: { content: [], totalElements: 0, totalPages: 0, size: 10, number: 0 },
+      }).as('getAccountsEmpty');
+
+      cy.visit('/employee/accounts', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.contains('Nema pronadjenih racuna', { timeout: 10000 }).should('be.visible');
+    });
+  });
+});

--- a/src/pages/Employee/AccountsPortalPage.tsx
+++ b/src/pages/Employee/AccountsPortalPage.tsx
@@ -1,70 +1,114 @@
-// TODO [FE2-14a] @Jovan - Employee portal: Pregled svih racuna (admin/employee)
-//
-// Ova stranica je dostupna samo zaposlenima.
-// Prikazuje sve racune u sistemu sa filterima i pretragom.
-// - accountService.getAll(filters) sa paginacijom
-// - Filteri: po emailu vlasnika, tipu racuna, statusu
-// - Akcije: promena statusa racuna (activate/block/deactivate)
-// - Link na detalje racuna
-// - Link na CreateAccountPage za novi racun
-// - Spec: "Portal racuna" iz Celine 2 (employee section)
+// FE2-14a: Employee portal - pregled svih racuna sa filterima
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  SlidersHorizontal,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  CreditCard,
+  Search,
+} from 'lucide-react';
 import { toast } from '@/lib/notify';
 import { accountService } from '@/services/accountService';
 import type { Account, AccountStatus, AccountType } from '@/types/celina2';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
-function asArray<T>(value: unknown): T[] {
-  return Array.isArray(value) ? (value as T[]) : [];
+const accountTypeLabels: Record<string, string> = {
+  TEKUCI: 'Tekuci',
+  DEVIZNI: 'Devizni',
+  POSLOVNI: 'Poslovni',
+};
+
+const accountTypeBadgeVariant: Record<string, 'info' | 'success' | 'warning'> = {
+  TEKUCI: 'info',
+  DEVIZNI: 'success',
+  POSLOVNI: 'warning',
+};
+
+const statusLabels: Record<string, string> = {
+  ACTIVE: 'Aktivan',
+  BLOCKED: 'Blokiran',
+  INACTIVE: 'Neaktivan',
+};
+
+const statusVariant: Record<string, 'success' | 'destructive' | 'secondary'> = {
+  ACTIVE: 'success',
+  BLOCKED: 'destructive',
+  INACTIVE: 'secondary',
+};
+
+function formatBalance(amount: number, currency: string): string {
+  return `${amount.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
 }
 
-function statusClass(status: AccountStatus): string {
-  if (status === 'ACTIVE') return 'bg-green-100 text-green-700';
-  if (status === 'BLOCKED') return 'bg-red-100 text-red-700';
-  return 'bg-muted text-muted-foreground';
-}
-
-function formatAmount(value: number | null | undefined, decimals = 2): string {
-  const num = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(num) ? num.toFixed(decimals) : (0).toFixed(decimals);
+function formatAccountNumber(accountNumber: string): string {
+  if (accountNumber.length !== 18) return accountNumber;
+  return `${accountNumber.slice(0, 3)}-${accountNumber.slice(3, 16)}-${accountNumber.slice(16)}`;
 }
 
 export default function AccountsPortalPage() {
   const navigate = useNavigate();
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const [ownerEmail, setOwnerEmail] = useState('');
-  const [accountType, setAccountType] = useState<AccountType | 'ALL'>('ALL');
-  const [status, setStatus] = useState<AccountStatus | 'ALL'>('ALL');
+  const [accountType, setAccountType] = useState<AccountType | undefined>(undefined);
+  const [status, setStatus] = useState<AccountStatus | undefined>(undefined);
+  const [showFilters, setShowFilters] = useState(false);
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(1);
+  const [rowsPerPage] = useState(10);
+  const [totalElements, setTotalElements] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
 
-  const loadAccounts = async () => {
+  const loadAccounts = useCallback(async () => {
     setLoading(true);
+    setError('');
     try {
       const response = await accountService.getAll({
         ownerEmail: ownerEmail || undefined,
-        accountType: accountType === 'ALL' ? undefined : accountType,
-        status: status === 'ALL' ? undefined : status,
+        accountType,
+        status,
         page,
-        limit: 10,
+        limit: rowsPerPage,
       });
-      setAccounts(asArray<Account>(response.content));
-      setTotalPages(Math.max(1, response.totalPages));
+      setAccounts(Array.isArray(response.content) ? response.content : []);
+      setTotalElements(response.totalElements ?? 0);
+      setTotalPages(response.totalPages ?? 0);
     } catch {
-      toast.error('Neuspešno učitavanje računa.');
+      setError('Greska pri ucitavanju racuna.');
       setAccounts([]);
+      setTotalElements(0);
+      setTotalPages(0);
     } finally {
       setLoading(false);
     }
-  };
+  }, [ownerEmail, accountType, status, page, rowsPerPage]);
 
   useEffect(() => {
     loadAccounts();
-  }, [ownerEmail, accountType, status, page]);
+  }, [loadAccounts]);
 
   useEffect(() => {
     setPage(0);
@@ -73,86 +117,146 @@ export default function AccountsPortalPage() {
   const changeStatus = async (accountId: number, nextStatus: AccountStatus) => {
     try {
       await accountService.changeStatus(accountId, nextStatus);
-      toast.success('Status računa je ažuriran.');
+      toast.success('Status racuna je azuriran.');
       await loadAccounts();
     } catch {
       toast.error('Promena statusa nije uspela.');
     }
   };
 
+  const from = totalElements > 0 ? page * rowsPerPage + 1 : 0;
+  const to = Math.min((page + 1) * rowsPerPage, totalElements);
+
   return (
-    <div className="container mx-auto py-6 space-y-6">
+    <div className="space-y-4">
+      {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">Portal računa</h1>
-        <Button onClick={() => navigate('/employee/accounts/new')}>Kreiraj račun</Button>
+        <h1 className="text-3xl font-bold tracking-tight">Portal racuna</h1>
+        <div className="flex items-center gap-2">
+          <Button
+            variant={showFilters ? 'secondary' : 'outline'}
+            size="icon"
+            onClick={() => setShowFilters(!showFilters)}
+            title="Filteri"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => navigate('/employee/accounts/new')}>
+            <Plus className="mr-2 h-4 w-4" /> Kreiraj racun
+          </Button>
+        </div>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Filteri</CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
-          <input
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            placeholder="Email vlasnika"
-            value={ownerEmail}
-            onChange={(e) => setOwnerEmail(e.target.value)}
-          />
-          <select
-            title="Tip računa"
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={accountType}
-            onChange={(e) => setAccountType(e.target.value as AccountType | 'ALL')}
-          >
-            <option value="ALL">Svi tipovi</option>
-            <option value="TEKUCI">Tekući</option>
-            <option value="DEVIZNI">Devizni</option>
-            <option value="POSLOVNI">Poslovni</option>
-          </select>
-          <select
-            title="Status"
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-            value={status}
-            onChange={(e) => setStatus(e.target.value as AccountStatus | 'ALL')}
-          >
-            <option value="ALL">Svi statusi</option>
-            <option value="ACTIVE">ACTIVE</option>
-            <option value="BLOCKED">BLOCKED</option>
-            <option value="INACTIVE">INACTIVE</option>
-          </select>
-        </CardContent>
-      </Card>
+      {/* Filters */}
+      {showFilters && (
+        <Card className="p-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Email vlasnika</label>
+              <div className="relative">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Pretrazi po emailu..."
+                  value={ownerEmail}
+                  onChange={(e) => setOwnerEmail(e.target.value)}
+                  className="pl-8 w-[250px]"
+                />
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Tip racuna</label>
+              <Select
+                value={accountType ?? 'ALL'}
+                onValueChange={(val) => setAccountType(val === 'ALL' ? undefined : val as AccountType)}
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder="Svi tipovi" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">Svi tipovi</SelectItem>
+                  <SelectItem value="TEKUCI">Tekuci</SelectItem>
+                  <SelectItem value="DEVIZNI">Devizni</SelectItem>
+                  <SelectItem value="POSLOVNI">Poslovni</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Status</label>
+              <Select
+                value={status ?? 'ALL'}
+                onValueChange={(val) => setStatus(val === 'ALL' ? undefined : val as AccountStatus)}
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder="Svi statusi" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">Svi statusi</SelectItem>
+                  <SelectItem value="ACTIVE">Aktivan</SelectItem>
+                  <SelectItem value="BLOCKED">Blokiran</SelectItem>
+                  <SelectItem value="INACTIVE">Neaktivan</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </Card>
+      )}
 
+      {/* Error */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Accounts table */}
       {loading ? (
-        <p className="text-muted-foreground">Učitavanje računa...</p>
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
       ) : (
         <Card>
-          <CardContent className="pt-6 overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b">
-                  <th className="text-left py-2">Vlasnik</th>
-                  <th className="text-left py-2">Broj računa</th>
-                  <th className="text-left py-2">Tip</th>
-                  <th className="text-left py-2">Valuta</th>
-                  <th className="text-left py-2">Stanje</th>
-                  <th className="text-left py-2">Status</th>
-                  <th className="text-left py-2">Akcije</th>
-                </tr>
-              </thead>
-              <tbody>
-                {asArray<Account>(accounts).map((account) => (
-                  <tr key={account.id} className="border-b">
-                    <td className="py-2">{account.ownerName}</td>
-                    <td className="py-2">{account.accountNumber}</td>
-                    <td className="py-2">{account.accountType}</td>
-                    <td className="py-2">{account.currency}</td>
-                    <td className="py-2">{formatAmount(account.balance)}</td>
-                    <td className="py-2">
-                      <span className={`px-2 py-1 rounded text-xs font-medium ${statusClass(account.status)}`}>{account.status}</span>
-                    </td>
-                    <td className="py-2">
-                      <div className="flex flex-wrap gap-2">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Vlasnik</TableHead>
+                <TableHead>Broj racuna</TableHead>
+                <TableHead>Tip</TableHead>
+                <TableHead>Stanje</TableHead>
+                <TableHead>Valuta</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Akcije</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {accounts.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                    Nema pronadjenih racuna
+                  </TableCell>
+                </TableRow>
+              ) : (
+                accounts.map((account) => (
+                  <TableRow key={account.id}>
+                    <TableCell>{account.ownerName}</TableCell>
+                    <TableCell className="font-medium">
+                      {formatAccountNumber(account.accountNumber)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={accountTypeBadgeVariant[account.accountType]}>
+                        {accountTypeLabels[account.accountType]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {formatBalance(account.availableBalance, account.currency)}
+                    </TableCell>
+                    <TableCell>{account.currency}</TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant[account.status]}>
+                        {statusLabels[account.status] || account.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
                         {account.status === 'ACTIVE' && (
                           <Button size="sm" variant="outline" onClick={() => changeStatus(account.id, 'BLOCKED')}>
                             Blokiraj
@@ -171,35 +275,63 @@ export default function AccountsPortalPage() {
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => navigate(account.accountType === 'POSLOVNI' ? `/accounts/${account.id}/business` : `/accounts/${account.id}`)}
+                          onClick={() => navigate(`/employee/accounts/${account.id}/cards`)}
+                          title="Kartice"
+                        >
+                          <CreditCard className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => navigate(
+                            account.accountType === 'POSLOVNI'
+                              ? `/accounts/${account.id}/business`
+                              : `/accounts/${account.id}`
+                          )}
                         >
                           Detalji
                         </Button>
                       </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
 
-            <div className="mt-4 flex items-center justify-end gap-2">
-              <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0}>
-                Prethodna
-              </Button>
-              <span className="text-sm text-muted-foreground">Strana {page + 1} / {totalPages}</span>
+          {/* Pagination */}
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <div className="text-sm text-muted-foreground">
+              {totalElements > 0
+                ? `${from}–${to} od ${totalElements}`
+                : '0 rezultata'}
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                Strana {page + 1} / {Math.max(1, totalPages)}
+              </span>
               <Button
                 variant="outline"
-                size="sm"
-                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                disabled={page >= totalPages - 1}
+                size="icon"
+                className="h-8 w-8"
+                disabled={page === 0}
+                onClick={() => setPage(page - 1)}
               >
-                Sledeća
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                disabled={page >= totalPages - 1}
+                onClick={() => setPage(page + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
               </Button>
             </div>
-          </CardContent>
+          </div>
         </Card>
       )}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Upgraded AccountsPortalPage with shadcn Table, Badge, Select, Input components
- Filters: owner email search, account type, account status
- Server-side pagination with page info display
- Status and type badges with color coding
- sr-RS locale formatting, formatted account numbers
- Action buttons: block/activate/deactivate, cards link, details
- Loading spinner and error/empty states

## Note
API endpoints use placeholder URLs (FIXME in services). Update when backend confirms actual endpoints.

## Test plan
- [x] E2E tests pass (`cypress/e2e/employee-accounts-portal.cy.ts`)
- [x] ESLint passes
- [x] Production build passes
- [ ] Verify with real backend once endpoints are ready

Closes #29