### PR TITLE
feat: [FE2-14b] polish employee account cards portal

### DIFF
--- a/cypress/e2e/employee-account-cards.cy.ts
+++ b/cypress/e2e/employee-account-cards.cy.ts
@@ -1,0 +1,243 @@
+/// <reference types="cypress" />
+
+const MOCK_ACCOUNT = {
+  id: 5, accountNumber: '265000000000000550', name: 'Devizni racun - RSD',
+  accountType: 'DEVIZNI', status: 'ACTIVE', balance: 1150000, availableBalance: 1100000.0,
+  reservedBalance: 50000, dailyLimit: 500000, monthlyLimit: 2000000,
+  dailySpending: 0, monthlySpending: 0, maintenanceFee: 500,
+  currency: 'RSD', ownerName: 'Lazar Petrovic', createdAt: '2025-01-25',
+};
+
+const MOCK_CARDS = [
+  {
+    id: 1, cardNumber: '4111111111111234', cardType: 'VISA',
+    accountNumber: '265000000000000550', holderName: 'Lazar Petrovic',
+    expirationDate: '2027-06-30', status: 'ACTIVE', limit: 100000,
+    createdAt: '2025-01-25',
+  },
+  {
+    id: 2, cardNumber: '5500000000005678', cardType: 'MASTERCARD',
+    accountNumber: '265000000000000550', holderName: 'Lazar Petrovic',
+    expirationDate: '2026-12-31', status: 'BLOCKED', limit: 50000,
+    createdAt: '2025-02-10',
+  },
+  {
+    id: 3, cardNumber: '9891000000009012', cardType: 'DINACARD',
+    accountNumber: '265000000000000550', holderName: 'Lazar Petrovic',
+    expirationDate: '2025-06-30', status: 'DEACTIVATED', limit: 0,
+    createdAt: '2024-06-01',
+  },
+];
+
+function setupEmployeeSession(win: Cypress.AUTWindow) {
+  win.sessionStorage.setItem('accessToken', 'fake-access-token');
+  win.sessionStorage.setItem('refreshToken', 'fake-refresh-token');
+  win.sessionStorage.setItem(
+    'user',
+    JSON.stringify({
+      id: 1, email: 'admin@test.com', username: 'admin',
+      firstName: 'Admin', lastName: 'User',
+      permissions: ['ADMIN'],
+    })
+  );
+}
+
+describe('Employee Account Cards Portal', () => {
+  describe('Pristup sa pretragom', () => {
+    beforeEach(() => {
+      cy.visit('/employee/cards', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.contains('Portal kartica', { timeout: 10000 }).should('be.visible');
+    });
+
+    it('prikazuje naslov stranice', () => {
+      cy.contains('h1', 'Portal kartica').should('be.visible');
+    });
+
+    it('prikazuje dugme za nazad', () => {
+      cy.contains('Nazad na portal racuna').should('be.visible');
+    });
+
+    it('prikazuje polje za pretragu', () => {
+      cy.get('input[placeholder*="broj racuna"]').should('be.visible');
+    });
+
+    it('prikazuje dugme za pretragu', () => {
+      cy.contains('button', 'Pretrazi').should('be.visible');
+    });
+
+    it('prikazuje dugme za novu karticu', () => {
+      cy.contains('button', 'Nova kartica').should('be.visible');
+    });
+
+    it('prikazuje poruku kada nema pretrazenog racuna', () => {
+      cy.contains('Pretrazite racun da biste videli kartice').should('be.visible');
+    });
+  });
+
+  describe('Pristup sa rute /employee/accounts/:id/cards', () => {
+    beforeEach(() => {
+      cy.intercept('GET', 'http://localhost:8080/accounts/5', {
+        statusCode: 200,
+        body: MOCK_ACCOUNT,
+      }).as('getAccount');
+
+      cy.intercept('GET', 'http://localhost:8080/accounts/number/265000000000000550', {
+        statusCode: 200,
+        body: MOCK_ACCOUNT,
+      }).as('getAccountByNumber');
+
+      cy.intercept('GET', 'http://localhost:8080/cards/account/265000000000000550', {
+        statusCode: 200,
+        body: MOCK_CARDS,
+      }).as('getCards');
+
+      cy.visit('/employee/accounts/5/cards', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.contains('Portal kartica', { timeout: 10000 }).should('be.visible');
+      cy.wait('@getAccount');
+    });
+
+    it('popunjava broj racuna iz rute', () => {
+      cy.get('input[placeholder*="broj racuna"]').should('have.value', '265000000000000550');
+    });
+
+    it('prikazuje informacije o racunu', () => {
+      cy.contains('Lazar Petrovic').should('be.visible');
+    });
+
+    it('prikazuje tabelu kartica', () => {
+      cy.get('table').should('be.visible');
+      cy.contains('th', 'Broj kartice').should('be.visible');
+      cy.contains('th', 'Tip').should('be.visible');
+      cy.contains('th', 'Limit').should('be.visible');
+      cy.contains('th', 'Status').should('be.visible');
+      cy.contains('th', 'Akcije').should('be.visible');
+    });
+
+    it('prikazuje kartice u tabeli', () => {
+      cy.get('table tbody tr').should('have.length', 3);
+    });
+
+    it('prikazuje maskirani broj kartice', () => {
+      cy.contains('**** **** **** 1234').should('be.visible');
+    });
+
+    it('prikazuje badge za tip kartice', () => {
+      cy.get('table').within(() => {
+        cy.contains('Visa').should('exist');
+        cy.contains('Mastercard').should('exist');
+        cy.contains('DinaCard').should('exist');
+      });
+    });
+
+    it('prikazuje badge za status kartice', () => {
+      cy.get('table').within(() => {
+        cy.contains('Aktivna').should('exist');
+        cy.contains('Blokirana').should('exist');
+        cy.contains('Deaktivirana').should('exist');
+      });
+    });
+
+    describe('Akcije nad karticama', () => {
+      it('prikazuje dugme za blokiranje aktivne kartice', () => {
+        cy.get('table tbody tr').first().within(() => {
+          cy.get('button[title="Blokiraj"]').should('exist');
+        });
+      });
+
+      it('prikazuje dugme za deblokiranje blokirane kartice', () => {
+        cy.get('table tbody tr').eq(1).within(() => {
+          cy.get('button[title="Deblokiraj"]').should('exist');
+        });
+      });
+
+      it('ne prikazuje dugme za deaktiviranje deaktivirane kartice', () => {
+        cy.get('table tbody tr').eq(2).within(() => {
+          cy.get('button[title="Deaktiviraj"]').should('not.exist');
+        });
+      });
+
+      it('poziva API za blokiranje kartice', () => {
+        cy.intercept('PATCH', 'http://localhost:8080/cards/1/block', {
+          statusCode: 200,
+          body: {},
+        }).as('blockCard');
+
+        cy.get('table tbody tr').first().within(() => {
+          cy.get('button[title="Blokiraj"]').click();
+        });
+
+        cy.wait('@blockCard');
+      });
+    });
+
+    describe('Kreiranje kartice', () => {
+      beforeEach(() => {
+        cy.contains('button', 'Nova kartica').click();
+      });
+
+      it('prikazuje formu za kreiranje', () => {
+        cy.contains('Tip kartice').should('be.visible');
+        cy.contains('button', 'Kreiraj karticu').should('be.visible');
+        cy.contains('button', 'Otkazi').should('be.visible');
+      });
+
+      it('prikazuje select za tip kartice', () => {
+        cy.contains('Izaberite tip').should('be.visible');
+      });
+
+      it('sakriva formu klikom na Otkazi', () => {
+        cy.contains('button', 'Otkazi').click();
+        cy.contains('Tip kartice').should('not.exist');
+      });
+
+      it('poziva API za kreiranje kartice', () => {
+        cy.intercept('POST', 'http://localhost:8080/cards', {
+          statusCode: 200,
+          body: { id: 10, cardNumber: '4111111111119999', cardType: 'VISA', status: 'ACTIVE' },
+        }).as('createCard');
+
+        cy.intercept('POST', 'http://localhost:8080/cards/10/request-verification', {
+          statusCode: 200,
+          body: {},
+        }).as('verifyCard');
+
+        cy.contains('Izaberite tip').click();
+        cy.get('[role="option"]').contains('Visa').click();
+        cy.contains('button', 'Kreiraj karticu').click();
+
+        cy.wait('@createCard');
+      });
+    });
+  });
+
+  describe('Prazno stanje i greske', () => {
+    it('prikazuje poruku kada nema kartica', () => {
+      cy.intercept('GET', 'http://localhost:8080/accounts/5', {
+        statusCode: 200,
+        body: MOCK_ACCOUNT,
+      }).as('getAccount');
+
+      cy.intercept('GET', 'http://localhost:8080/accounts/number/265000000000000550', {
+        statusCode: 200,
+        body: MOCK_ACCOUNT,
+      }).as('getAccountByNumber');
+
+      cy.intercept('GET', 'http://localhost:8080/cards/account/265000000000000550', {
+        statusCode: 200,
+        body: [],
+      }).as('getCardsEmpty');
+
+      cy.visit('/employee/accounts/5/cards', {
+        onBeforeLoad(win) { setupEmployeeSession(win); },
+      });
+
+      cy.contains('Nema kartica za ovaj racun', { timeout: 10000 }).should('be.visible');
+    });
+  });
+});

--- a/src/pages/Employee/AccountCardsPage.tsx
+++ b/src/pages/Employee/AccountCardsPage.tsx
@@ -1,86 +1,137 @@
-// TODO [FE2-14b] @Jovan - Employee portal: Pregled kartica po racunu
-// TODO [FE2-14b] @Jovan - Employee portal: Upravljanje karticama (block/unblock/deactivate)
-//
-// Ova stranica je dostupna samo zaposlenima.
-// Omogucava pregled i upravljanje karticama za odredjeni racun.
-// - Pretraga po broju racuna ili email-u vlasnika
-// - cardService.getByAccount(accountNumber) za fetch
-// - Akcije: blokiranje, deblokiranje, deaktivacija kartica
-// - Kreiranje nove kartice za racun
-// - Spec: "Portal kartica" iz Celine 2 (employee section)
-// TODO [FE2-14b] @Jovan - Podrzati otvoranje preko rute /employee/accounts/:id/cards (prepopunjen accountId)
+// FE2-14b: Employee portal - upravljanje karticama po racunu
 
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Loader2,
+  Search,
+  Plus,
+  CreditCard as CreditCardIcon,
+  ShieldCheck,
+  ShieldOff,
+  ShieldX,
+} from 'lucide-react';
 import { toast } from '@/lib/notify';
 import { accountService } from '@/services/accountService';
 import { cardService } from '@/services/cardService';
 import type { Account, CardType, Card as BankCard } from '@/types/celina2';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const cardStatusLabels: Record<string, string> = {
+  ACTIVE: 'Aktivna',
+  BLOCKED: 'Blokirana',
+  DEACTIVATED: 'Deaktivirana',
+};
+
+const cardStatusVariant: Record<string, 'success' | 'destructive' | 'secondary'> = {
+  ACTIVE: 'success',
+  BLOCKED: 'destructive',
+  DEACTIVATED: 'secondary',
+};
+
+const cardTypeLabels: Record<string, string> = {
+  VISA: 'Visa',
+  MASTERCARD: 'Mastercard',
+  DINACARD: 'DinaCard',
+  AMERICAN_EXPRESS: 'American Express',
+};
 
 function maskCardNumber(number: string): string {
   return `**** **** **** ${number.slice(-4)}`;
 }
 
-function formatAmount(value: number | null | undefined, decimals = 2): string {
-  const num = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(num) ? num.toFixed(decimals) : (0).toFixed(decimals);
+function formatBalance(amount: number, currency: string): string {
+  return `${amount.toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
 }
 
-function formatDate(value: string | null | undefined): string {
-  if (!value) return '-';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? '-' : date.toLocaleDateString('sr-RS');
+function formatAccountNumber(accountNumber: string): string {
+  if (accountNumber.length !== 18) return accountNumber;
+  return `${accountNumber.slice(0, 3)}-${accountNumber.slice(3, 16)}-${accountNumber.slice(16)}`;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('sr-RS', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 export default function AccountCardsPage() {
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const [accountNumber, setAccountNumber] = useState('');
   const [account, setAccount] = useState<Account | null>(null);
   const [cards, setCards] = useState<BankCard[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
   const [processingId, setProcessingId] = useState<number | null>(null);
+  const [showCreateCard, setShowCreateCard] = useState(false);
+  const [newCardType, setNewCardType] = useState<CardType | ''>('');
+  const [isCreating, setIsCreating] = useState(false);
 
+  // Load account and cards from route param
   useEffect(() => {
     const loadById = async () => {
       if (!id) return;
       const accountId = Number(id);
       if (!accountId || Number.isNaN(accountId)) return;
+      setLoading(true);
       try {
         const accountData = await accountService.getById(accountId);
         setAccountNumber(accountData.accountNumber);
         setAccount(accountData);
+        const cardsData = await cardService.getByAccount(accountData.accountNumber);
+        setCards(Array.isArray(cardsData) ? cardsData : []);
       } catch {
-        toast.error('Neuspešno učitavanje računa iz rute.');
+        toast.error('Greska pri ucitavanju racuna.');
+      } finally {
+        setLoading(false);
       }
     };
-
     loadById();
   }, [id]);
 
-  const searchCards = async () => {
+  const searchCards = useCallback(async () => {
     if (!accountNumber) {
-      toast.error('Unesite broj računa.');
+      toast.error('Unesite broj racuna.');
       return;
     }
 
     setLoading(true);
+    setError('');
     try {
       const [accountData, cardsData] = await Promise.all([
         accountService.getByAccountNumber(accountNumber),
         cardService.getByAccount(accountNumber),
       ]);
       setAccount(accountData);
-      setCards(cardsData);
+      setCards(Array.isArray(cardsData) ? cardsData : []);
     } catch {
-      toast.error('Pretraga kartica nije uspela.');
+      setError('Pretraga kartica nije uspela.');
       setCards([]);
       setAccount(null);
     } finally {
       setLoading(false);
     }
-  };
+  }, [accountNumber]);
 
   const runAction = async (cardId: number, action: 'block' | 'unblock' | 'deactivate') => {
     setProcessingId(cardId);
@@ -88,6 +139,7 @@ export default function AccountCardsPage() {
       if (action === 'block') await cardService.block(cardId);
       if (action === 'unblock') await cardService.unblock(cardId);
       if (action === 'deactivate') await cardService.deactivate(cardId);
+      toast.success('Status kartice je azuriran.');
       await searchCards();
     } catch {
       toast.error('Akcija nad karticom nije uspela.');
@@ -97,93 +149,200 @@ export default function AccountCardsPage() {
   };
 
   const createNewCard = async () => {
-    if (!accountNumber) {
-      toast.error('Prvo izaberite račun.');
+    if (!accountNumber || !newCardType) {
+      toast.error('Izaberite tip kartice.');
       return;
     }
 
-    const cardTypeRaw = window.prompt('Unesite tip kartice: VISA, MASTERCARD, DINACARD, AMERICAN_EXPRESS');
-    if (!cardTypeRaw) return;
-    const cardType = cardTypeRaw.toUpperCase() as CardType;
-    if (!['VISA', 'MASTERCARD', 'DINACARD', 'AMERICAN_EXPRESS'].includes(cardType)) {
-      toast.error('Neispravan tip kartice.');
-      return;
-    }
-
+    setIsCreating(true);
     try {
-      const created = await cardService.create({ accountNumber, cardType });
+      const created = await cardService.create({ accountNumber, cardType: newCardType as CardType });
       await cardService.requestCardVerification(created.id);
       toast.success('Kartica kreirana. Poslat je zahtev za verifikaciju.');
+      setShowCreateCard(false);
+      setNewCardType('');
       await searchCards();
     } catch {
       toast.error('Kreiranje kartice nije uspelo.');
+    } finally {
+      setIsCreating(false);
     }
   };
 
   return (
-    <div className="container mx-auto py-6 space-y-6">
-      <h1 className="text-3xl font-bold">Portal kartica</h1>
+    <div className="space-y-4">
+      {/* Back button */}
+      <Button variant="ghost" size="sm" onClick={() => navigate('/employee/accounts')}>
+        <ArrowLeft className="mr-2 h-4 w-4" /> Nazad na portal racuna
+      </Button>
 
-      <section>
-        <Card>
-          <CardContent className="pt-6 flex flex-col md:flex-row gap-3 md:items-center">
-            <input
-              className="flex-1 h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
-              placeholder="Broj računa (18 cifara)"
-              value={accountNumber}
-              onChange={(e) => setAccountNumber(e.target.value)}
-            />
-            <Button onClick={searchCards} disabled={loading}>{loading ? 'Pretraga...' : 'Pretraži'}</Button>
-            <Button variant="outline" onClick={createNewCard}>Kreiraj novu karticu</Button>
-          </CardContent>
-        </Card>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold tracking-tight">Portal kartica</h1>
+      </div>
 
+      {/* Search */}
+      <Card className="p-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1 min-w-[250px] space-y-1">
+            <label className="text-xs text-muted-foreground">Broj racuna</label>
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Unesite broj racuna (18 cifara)"
+                value={accountNumber}
+                onChange={(e) => setAccountNumber(e.target.value)}
+                className="pl-8"
+                onKeyDown={(e) => e.key === 'Enter' && searchCards()}
+              />
+            </div>
+          </div>
+          <Button onClick={searchCards} disabled={loading}>
+            {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Search className="mr-2 h-4 w-4" />}
+            Pretrazi
+          </Button>
+          <Button variant="outline" onClick={() => setShowCreateCard(!showCreateCard)}>
+            <Plus className="mr-2 h-4 w-4" /> Nova kartica
+          </Button>
+        </div>
+
+        {/* Account info */}
         {account && (
-          <p className="text-sm text-muted-foreground mt-2">
-            Račun: {account.accountNumber} | Vlasnik: {account.ownerName} | Status: {account.status}
-          </p>
-        )}
-      </section>
-
-      <section>
-        {!loading && cards.length === 0 ? (
-          <p className="text-muted-foreground">Nema kartica za ovaj račun.</p>
-        ) : (
-          <div className="grid gap-4 md:grid-cols-2">
-            {cards.map((card) => (
-              <Card key={card.id}>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-base">{card.cardType}</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2 text-sm">
-                  <p className="font-mono">{maskCardNumber(card.cardNumber)}</p>
-                  <p>Status: <span className="font-medium">{card.status}</span></p>
-                  <p>Limit: <span className="font-medium">{formatAmount(card.limit)}</span></p>
-                  <p>Istek: <span className="font-medium">{formatDate(card.expirationDate)}</span></p>
-                  <div className="flex flex-wrap gap-2 pt-1">
-                    {card.status === 'ACTIVE' && (
-                      <Button variant="outline" size="sm" onClick={() => runAction(card.id, 'block')} disabled={processingId === card.id}>
-                        Blokiraj
-                      </Button>
-                    )}
-                    {card.status === 'BLOCKED' && (
-                      <Button variant="outline" size="sm" onClick={() => runAction(card.id, 'unblock')} disabled={processingId === card.id}>
-                        Deblokiraj
-                      </Button>
-                    )}
-                    {card.status !== 'DEACTIVATED' && (
-                      <Button variant="destructive" size="sm" onClick={() => runAction(card.id, 'deactivate')} disabled={processingId === card.id}>
-                        Deaktiviraj
-                      </Button>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <span>Racun: <strong>{formatAccountNumber(account.accountNumber)}</strong></span>
+            <span>Vlasnik: <strong>{account.ownerName}</strong></span>
+            <Badge variant={account.status === 'ACTIVE' ? 'success' : account.status === 'BLOCKED' ? 'destructive' : 'secondary'}>
+              {account.status === 'ACTIVE' ? 'Aktivan' : account.status === 'BLOCKED' ? 'Blokiran' : 'Neaktivan'}
+            </Badge>
           </div>
         )}
-      </section>
+      </Card>
+
+      {/* Create card form */}
+      {showCreateCard && account && (
+        <Card className="p-4">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Tip kartice</label>
+              <Select value={newCardType} onValueChange={(val) => setNewCardType(val as CardType)}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue placeholder="Izaberite tip" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="VISA">Visa</SelectItem>
+                  <SelectItem value="MASTERCARD">Mastercard</SelectItem>
+                  <SelectItem value="DINACARD">DinaCard</SelectItem>
+                  <SelectItem value="AMERICAN_EXPRESS">American Express</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button onClick={createNewCard} disabled={isCreating || !newCardType}>
+              {isCreating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
+              Kreiraj karticu
+            </Button>
+            <Button variant="ghost" onClick={() => { setShowCreateCard(false); setNewCardType(''); }}>
+              Otkazi
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      {/* Error */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Cards table */}
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : !account ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <CreditCardIcon className="h-12 w-12 mb-3 opacity-30" />
+          <p>Pretrazite racun da biste videli kartice</p>
+        </div>
+      ) : cards.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <CreditCardIcon className="h-12 w-12 mb-3 opacity-30" />
+          <p>Nema kartica za ovaj racun</p>
+        </div>
+      ) : (
+        <Card>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Broj kartice</TableHead>
+                <TableHead>Tip</TableHead>
+                <TableHead>Vlasnik</TableHead>
+                <TableHead>Limit</TableHead>
+                <TableHead>Istek</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Akcije</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {cards.map((card) => (
+                <TableRow key={card.id}>
+                  <TableCell className="font-mono">{maskCardNumber(card.cardNumber)}</TableCell>
+                  <TableCell>
+                    <Badge variant="info">{cardTypeLabels[card.cardType] || card.cardType}</Badge>
+                  </TableCell>
+                  <TableCell>{card.holderName}</TableCell>
+                  <TableCell className="font-medium">
+                    {formatBalance(card.limit, account.currency)}
+                  </TableCell>
+                  <TableCell>{formatDate(card.expirationDate)}</TableCell>
+                  <TableCell>
+                    <Badge variant={cardStatusVariant[card.status]}>
+                      {cardStatusLabels[card.status] || card.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      {card.status === 'ACTIVE' && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => runAction(card.id, 'block')}
+                          disabled={processingId === card.id}
+                          title="Blokiraj"
+                        >
+                          <ShieldOff className="h-4 w-4" />
+                        </Button>
+                      )}
+                      {card.status === 'BLOCKED' && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => runAction(card.id, 'unblock')}
+                          disabled={processingId === card.id}
+                          title="Deblokiraj"
+                        >
+                          <ShieldCheck className="h-4 w-4" />
+                        </Button>
+                      )}
+                      {card.status !== 'DEACTIVATED' && (
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => runAction(card.id, 'deactivate')}
+                          disabled={processingId === card.id}
+                          title="Deaktiviraj"
+                        >
+                          <ShieldX className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      )}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- Upgraded AccountCardsPage with shadcn Table, Badge, Select, Input components
- Select dropdown for card type instead of window.prompt
- Card status and type badges with color coding
- Auto-loads cards when accessed via `/employee/accounts/:id/cards`
- Search by account number, icon action buttons (block/unblock/deactivate)
- Loading spinner, empty/error states, back navigation

## Note
API endpoints use placeholder URLs (FIXME in services). Update when backend confirms actual endpoints.

## Test plan
- [x] E2E tests pass (`cypress/e2e/employee-account-cards.cy.ts`)
- [x] ESLint passes
- [x] Production build passes
- [ ] Verify with real backend once endpoints are ready

Closes #30