### PR TITLE
FE2-06: implement recipients CRUD and add E2E tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   allowCypressEnv: false,
 
   e2e: {
-    baseUrl: 'http://localhost:5173',
+    baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/recipients-page.cy.ts
+++ b/cypress/e2e/recipients-page.cy.ts
@@ -1,0 +1,580 @@
+describe('Recipients Page', () => {
+  const adminEmail = 'marko.petrovic@banka.rs';
+  const adminPassword = 'Admin12345';
+
+  const recipient1 = {
+    id: 1,
+    name: 'Elektroprivreda Srbije',
+    accountNumber: '160123456789012345',
+    address: 'Bulevar umetnosti 12, Beograd',
+    phoneNumber: '0111234567',
+  };
+
+  const recipient2 = {
+    id: 2,
+    name: 'Telekom Srbija',
+    accountNumber: '205987654321000011',
+    address: 'Takovska 2, Beograd',
+    phoneNumber: '011222333',
+  };
+
+  const recipient3 = {
+    id: 3,
+    name: 'Streaming Servis',
+    accountNumber: '340555666777888900',
+    address: '',
+    phoneNumber: '',
+  };
+
+  const recipientsInitial = [recipient1, recipient2, recipient3];
+
+  const loginAsAdminViaUi = () => {
+    cy.session([adminEmail, adminPassword], () => {
+      cy.visit('/login');
+
+      cy.get('#email').should('be.visible').clear().type(adminEmail);
+      cy.get('#password')
+        .should('be.visible')
+        .clear()
+        .type(adminPassword, { log: false });
+
+      cy.contains('button', 'Prijavi se').click();
+      cy.url().should('include', '/home');
+    });
+  };
+
+  const mockRecipientsList = (body = recipientsInitial) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      {
+        statusCode: 200,
+        body,
+      }
+    ).as('getRecipients');
+  };
+
+  const mockCreateRecipient = () => {
+    cy.intercept(
+      {
+        method: /POST|PUT/,
+        pathname: /\/recipients(\/.*)?$/,
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 999,
+            ...req.body,
+          },
+        });
+      }
+    ).as('createRecipient');
+  };
+
+  const mockUpdateRecipient = () => {
+    cy.intercept(
+      {
+        method: /PUT|PATCH|POST/,
+        pathname: /\/recipients(\/\d+)?$/,
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: Number(req.url.split('/').pop()),
+            ...req.body,
+          },
+        });
+      }
+    ).as('updateRecipient');
+  };
+
+  const mockDeleteRecipient = () => {
+    cy.intercept(
+      {
+        method: 'DELETE',
+        pathname: /\/recipients\/\d+$/,
+      },
+      {
+        statusCode: 200,
+        body: {},
+      }
+    ).as('deleteRecipient');
+  };
+
+  const visitRecipientsPage = () => {
+    cy.visit('/home');
+
+    cy.window().then((win) => {
+      win.history.pushState({}, '', '/payments/recipients');
+      win.dispatchEvent(new win.PopStateEvent('popstate'));
+    });
+  };
+
+  beforeEach(() => {
+    mockRecipientsList();
+    mockCreateRecipient();
+    mockUpdateRecipient();
+    mockDeleteRecipient();
+    loginAsAdminViaUi();
+  });
+
+  it('renders page and loads recipients list', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('h1', 'Primaoci plaćanja').should('be.visible');
+    cy.contains('Sačuvani primaoci').should('be.visible');
+    cy.contains('Dodaj primaoca').should('be.visible');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]').should('exist');
+
+    cy.contains('Elektroprivreda Srbije').should('be.visible');
+    cy.contains('160123456789012345').should('be.visible');
+    cy.contains('Bulevar umetnosti 12, Beograd').should('be.visible');
+    cy.contains('0111234567').should('be.visible');
+
+    cy.contains('Telekom Srbija').should('be.visible');
+    cy.contains('Streaming Servis').should('be.visible');
+  });
+
+  it('shows empty state when there are no recipients', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      {
+        statusCode: 200,
+        body: [],
+      }
+    ).as('getRecipientsEmpty');
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipientsEmpty');
+    cy.contains('Nemate sačuvanih primalaca.').should('be.visible');
+  });
+
+  it('supports search by recipient name', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]')
+      .clear()
+      .type('Telekom');
+
+    cy.contains('Telekom Srbija').should('be.visible');
+    cy.contains('Elektroprivreda Srbije').should('not.exist');
+    cy.contains('Streaming Servis').should('not.exist');
+  });
+
+  it('supports search by account number', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]')
+      .clear()
+      .type('340555666777888900');
+
+    cy.contains('Streaming Servis').should('be.visible');
+    cy.contains('Telekom Srbija').should('not.exist');
+    cy.contains('Elektroprivreda Srbije').should('not.exist');
+  });
+
+  it('supports search by address', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]')
+      .clear()
+      .type('Takovska');
+
+    cy.contains('Telekom Srbija').should('be.visible');
+    cy.contains('Elektroprivreda Srbije').should('not.exist');
+  });
+
+  it('supports search by phone number', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]')
+      .clear()
+      .type('0111234567');
+
+    cy.contains('Elektroprivreda Srbije').should('be.visible');
+    cy.contains('Telekom Srbija').should('not.exist');
+  });
+
+  it('shows empty search state when no recipient matches search', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.get('input[placeholder="Pretraga po imenu, računu, adresi ili telefonu"]')
+      .clear()
+      .type('Nepostojeci primalac');
+
+    cy.contains('Nema primalaca koji odgovaraju pretrazi.').should('be.visible');
+  });
+
+  it('opens and closes create recipient form', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('button', 'Dodaj primaoca').click();
+    cy.contains('Novi primalac').should('be.visible');
+    cy.get('#create-name').should('exist');
+    cy.get('#create-account').should('exist');
+    cy.get('#create-address').should('exist');
+    cy.get('#create-phone').should('exist');
+
+    cy.contains('button', 'Zatvori formu').click();
+    cy.contains('Novi primalac').should('not.exist');
+  });
+
+  it('creates a new recipient successfully', () => {
+    let recipients = [...recipientsInitial];
+
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: recipients,
+        });
+      }
+    ).as('getRecipientsStateful');
+
+    cy.intercept(
+      {
+        method: /POST|PUT/,
+        pathname: /\/recipients(\/.*)?$/,
+      },
+      (req) => {
+        if (req.method === 'POST') {
+          const created = {
+            id: 4,
+            ...req.body,
+          };
+
+          recipients = [...recipients, created];
+
+          req.reply({
+            statusCode: 200,
+            body: created,
+          });
+        }
+      }
+    ).as('saveRecipient');
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipientsStateful');
+
+    cy.contains('button', 'Dodaj primaoca').click();
+
+    cy.get('#create-name').type('Infostan');
+    cy.get('#create-account').type('170123456789012312');
+
+    cy.contains('button', 'Sačuvaj primaoca').click();
+
+    cy.wait('@saveRecipient');
+    cy.wait('@getRecipientsStateful');
+
+    cy.contains('Infostan').should('be.visible');
+    cy.contains('Novi primalac').should('not.exist');
+  });
+
+  it('shows validation errors in create form', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('button', 'Dodaj primaoca').click();
+    cy.contains('button', 'Sačuvaj primaoca').click();
+
+    cy.get('#create-name').should('exist');
+    cy.get('#create-account').should('exist');
+    cy.get('.text-destructive').should('have.length.at.least', 1);
+    cy.get('@createRecipient.all').should('have.length', 0);
+  });
+
+  it('handles create recipient error gracefully', () => {
+    cy.intercept(
+      {
+        method: /POST|PUT/,
+        pathname: /\/recipients(\/.*)?$/,
+      },
+      {
+        statusCode: 500,
+        body: { message: 'Create failed' },
+      }
+    ).as('saveRecipientError');
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('button', 'Dodaj primaoca').click();
+
+    cy.get('#create-name').type('Infostan');
+    cy.get('#create-account').type('170123456789012312');
+
+    cy.contains('button', 'Sačuvaj primaoca').click();
+
+    cy.wait('@saveRecipientError');
+    cy.contains('Novi primalac').should('be.visible');
+  });
+
+  it('starts inline edit and prepopulates fields', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+
+    cy.get('#edit-name-2').should('have.value', 'Telekom Srbija');
+    cy.get('#edit-account-2').should('have.value', '205987654321000011');
+    cy.get('#edit-address-2').should('have.value', 'Takovska 2, Beograd');
+    cy.get('#edit-phone-2').should('have.value', '011222333');
+    cy.contains('button', 'Sačuvaj').should('be.visible');
+    cy.contains('button', 'Otkaži').should('be.visible');
+  });
+
+  it('cancels inline edit', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+
+    cy.get('#edit-name-2').clear().type('Novo ime');
+    cy.contains('button', 'Otkaži').click();
+
+    cy.get('#edit-name-2').should('not.exist');
+    cy.contains('Telekom Srbija').should('be.visible');
+  });
+
+  it('updates recipient successfully', () => {
+    let recipients = [...recipientsInitial];
+
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: recipients,
+        });
+      }
+    ).as('getRecipientsStatefulEdit');
+
+    cy.intercept(
+      {
+        method: /PUT|PATCH|POST/,
+        pathname: /\/recipients(\/\d+)?$/,
+      },
+      (req) => {
+        recipients = recipients.map((recipient) =>
+          recipient.id === 2
+            ? {
+                ...recipient,
+                ...req.body,
+              }
+            : recipient
+        );
+
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 2,
+            ...req.body,
+          },
+        });
+      }
+    ).as('saveRecipientEdit');
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipientsStatefulEdit');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+    cy.get('#edit-name-2').clear().type('Telekom Srbija Updated');
+
+    cy.contains('button', 'Sačuvaj').click();
+
+    cy.wait('@saveRecipientEdit');
+    cy.wait('@getRecipientsStatefulEdit');
+
+    cy.contains('Telekom Srbija Updated').should('be.visible');
+  });
+
+  it('shows validation errors in inline edit form', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+
+    cy.get('#edit-name-2').clear();
+    cy.get('#edit-account-2').clear();
+
+    cy.contains('button', 'Sačuvaj').click();
+
+    cy.get('.text-destructive').should('have.length.at.least', 1);
+    cy.get('@updateRecipient.all').should('have.length', 0);
+  });
+
+  it('handles update recipient error gracefully', () => {
+    cy.intercept(
+      {
+        method: /PUT|PATCH|POST/,
+        pathname: /\/recipients(\/\d+)?$/,
+      },
+      {
+        statusCode: 500,
+        body: { message: 'Update failed' },
+      }
+    ).as('saveRecipientEditError');
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+    cy.get('#edit-name-2').clear().type('Novo ime');
+
+    cy.contains('button', 'Sačuvaj').click();
+
+    cy.wait('@saveRecipientEditError');
+    cy.get('#edit-name-2').should('have.value', 'Novo ime');
+  });
+
+  it('deletes recipient after confirmation', () => {
+    let recipients = [...recipientsInitial];
+
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: recipients,
+        });
+      }
+    ).as('getRecipientsStatefulDelete');
+
+    cy.intercept(
+      {
+        method: 'DELETE',
+        pathname: '/recipients/1',
+      },
+      (req) => {
+        recipients = recipients.filter((recipient) => recipient.id !== 1);
+
+        req.reply({
+          statusCode: 200,
+          body: {},
+        });
+      }
+    ).as('deleteRecipientSuccess');
+
+    cy.on('window:confirm', () => true);
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipientsStatefulDelete');
+    cy.contains('tr', 'Elektroprivreda Srbije').contains('button', 'Obriši').click();
+
+    cy.wait('@deleteRecipientSuccess');
+    cy.wait('@getRecipientsStatefulDelete');
+
+    cy.get('tbody').should('not.contain', 'Elektroprivreda Srbije');
+  });
+
+  it('does not delete recipient when confirmation is cancelled', () => {
+    cy.on('window:confirm', () => false);
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Elektroprivreda Srbije').contains('button', 'Obriši').click();
+
+    cy.get('@deleteRecipient.all').should('have.length', 0);
+    cy.contains('Elektroprivreda Srbije').should('be.visible');
+  });
+
+  it('handles delete recipient error gracefully', () => {
+    cy.intercept(
+      {
+        method: 'DELETE',
+        pathname: '/recipients/1',
+      },
+      {
+        statusCode: 500,
+        body: { message: 'Delete failed' },
+      }
+    ).as('deleteRecipientError');
+
+    cy.on('window:confirm', () => true);
+
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Elektroprivreda Srbije').contains('button', 'Obriši').click();
+
+    cy.wait('@deleteRecipientError');
+    cy.contains('Elektroprivreda Srbije').should('be.visible');
+  });
+
+  it('shows save and cancel actions while a recipient row is in edit mode', () => {
+    visitRecipientsPage();
+
+    cy.wait('@getRecipients');
+
+    cy.contains('tr', 'Telekom Srbija').contains('button', 'Izmeni').click();
+
+    cy.get('#edit-name-2').should('exist');
+    cy.contains('button', 'Sačuvaj').should('be.visible');
+    cy.contains('button', 'Otkaži').should('be.visible');
+  });
+
+  it('shows loading state while recipients are loading', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/recipients',
+      },
+      {
+        delay: 1200,
+        statusCode: 200,
+        body: recipientsInitial,
+      }
+    ).as('getRecipientsDelayed');
+
+    visitRecipientsPage();
+
+    cy.contains('Učitavanje primalaca...', { timeout: 3000 }).should('be.visible');
+    cy.wait('@getRecipientsDelayed');
+    cy.contains('Učitavanje primalaca...').should('not.exist');
+  });
+});

--- a/src/pages/Payments/RecipientsPage.tsx
+++ b/src/pages/Payments/RecipientsPage.tsx
@@ -1,13 +1,3 @@
-// TODO [FE2-06a] @Elena - Primaoci: Lista sacuvanih primalaca placanja
-// TODO [FE2-06b] @Elena - Primaoci: CRUD operacije (dodaj/izmeni/obrisi)
-//
-// Ova stranica omogucava upravljanje listom sacuvanih primalaca placanja.
-// - paymentRecipientService.getAll() za prikaz
-// - CRUD: create, update, delete
-// - Forma za novog primaoca: ime, broj racuna, adresa (opciono), telefon (opciono)
-// - Inline edit ili modal za izmenu
-// - Potvrda pre brisanja (confirm dialog)
-
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -29,26 +19,46 @@ function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
+function normalizeValue(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
 export default function RecipientsPage() {
   const [recipients, setRecipients] = useState<PaymentRecipient[]>([]);
   const [loading, setLoading] = useState(true);
+
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingRecipient, setEditingRecipient] = useState<PaymentRecipient | null>(null);
+  const [editingRecipientId, setEditingRecipientId] = useState<number | null>(null);
+
   const [searchTerm, setSearchTerm] = useState('');
+
+  const [creating, setCreating] = useState(false);
+  const [updating, setUpdating] = useState(false);
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const createForm = useForm<CreateRecipientFormData>({
     resolver: zodResolver(createRecipientSchema),
-    defaultValues: { name: '', accountNumber: '', address: '', phoneNumber: '' },
+    defaultValues: {
+      name: '',
+      accountNumber: '',
+      address: '',
+      phoneNumber: '',
+    },
   });
 
   const editForm = useForm<EditRecipientFormData>({
     resolver: zodResolver(editRecipientSchema),
-    defaultValues: { name: '', accountNumber: '', address: '', phoneNumber: '' },
+    defaultValues: {
+      name: '',
+      accountNumber: '',
+      address: '',
+      phoneNumber: '',
+    },
   });
 
   const loadRecipients = async () => {
     setLoading(true);
+
     try {
       const data = await paymentRecipientService.getAll();
       setRecipients(asArray<PaymentRecipient>(data));
@@ -65,31 +75,70 @@ export default function RecipientsPage() {
   }, []);
 
   const filteredRecipients = useMemo(() => {
-    const term = searchTerm.trim().toLowerCase();
+    const term = normalizeValue(searchTerm);
     const safeRecipients = asArray<PaymentRecipient>(recipients);
+
     if (!term) return safeRecipients;
-    return safeRecipients.filter((recipient) => recipient.name.toLowerCase().includes(term));
+
+    return safeRecipients.filter((recipient) => {
+      const name = normalizeValue(recipient.name);
+      const accountNumber = normalizeValue(recipient.accountNumber);
+      const address = normalizeValue(recipient.address);
+      const phoneNumber = normalizeValue(recipient.phoneNumber);
+
+      return (
+        name.includes(term) ||
+        accountNumber.includes(term) ||
+        address.includes(term) ||
+        phoneNumber.includes(term)
+      );
+    });
   }, [recipients, searchTerm]);
 
-  const onCreate = async (data: CreateRecipientFormData) => {
+  const handleToggleCreateForm = () => {
+    const nextValue = !showCreateForm;
+    setShowCreateForm(nextValue);
+
+    if (!nextValue) {
+      createForm.reset({
+        name: '',
+        accountNumber: '',
+        address: '',
+        phoneNumber: '',
+      });
+    }
+  };
+
+  const handleCreate = async (data: CreateRecipientFormData) => {
+    setCreating(true);
+
     try {
       await paymentRecipientService.create({
-        name: data.name,
-        accountNumber: data.accountNumber,
-        address: data.address || undefined,
-        phoneNumber: data.phoneNumber || undefined,
+        name: data.name.trim(),
+        accountNumber: data.accountNumber.trim(),
+        address: data.address?.trim() || '',
+        phoneNumber: data.phoneNumber?.trim() || '',
       });
-      toast.success('Primaoc je uspešno dodat.');
-      createForm.reset();
+
+      toast.success('Primalac je uspešno dodat.');
+      createForm.reset({
+        name: '',
+        accountNumber: '',
+        address: '',
+        phoneNumber: '',
+      });
       setShowCreateForm(false);
       await loadRecipients();
     } catch {
       toast.error('Dodavanje primaoca nije uspelo.');
+    } finally {
+      setCreating(false);
     }
   };
 
   const startEdit = (recipient: PaymentRecipient) => {
-    setEditingRecipient(recipient);
+    setEditingRecipientId(recipient.id);
+
     editForm.reset({
       name: recipient.name,
       accountNumber: recipient.accountNumber,
@@ -98,31 +147,56 @@ export default function RecipientsPage() {
     });
   };
 
-  const onEdit = async (data: EditRecipientFormData) => {
-    if (!editingRecipient) return;
+  const cancelEdit = () => {
+    setEditingRecipientId(null);
+    editForm.reset({
+      name: '',
+      accountNumber: '',
+      address: '',
+      phoneNumber: '',
+    });
+  };
+
+  const handleEdit = async (data: EditRecipientFormData) => {
+    if (!editingRecipientId) return;
+
+    setUpdating(true);
+
     try {
-      await paymentRecipientService.update(editingRecipient.id, {
-        name: data.name,
-        accountNumber: data.accountNumber,
-        address: data.address || undefined,
-        phoneNumber: data.phoneNumber || undefined,
+      await paymentRecipientService.update(editingRecipientId, {
+        name: data.name.trim(),
+        accountNumber: data.accountNumber.trim(),
+        address: data.address?.trim() || '',
+        phoneNumber: data.phoneNumber?.trim() || '',
       });
-      toast.success('Primaoc je uspešno izmenjen.');
-      setEditingRecipient(null);
+
+      toast.success('Primalac je uspešno izmenjen.');
+      cancelEdit();
       await loadRecipients();
     } catch {
       toast.error('Izmena primaoca nije uspela.');
+    } finally {
+      setUpdating(false);
     }
   };
 
-  const onDelete = async (recipient: PaymentRecipient) => {
-    const confirmed = window.confirm(`Da li ste sigurni da želite da obrišete primaoca ${recipient.name}?`);
+  const handleDelete = async (recipient: PaymentRecipient) => {
+    const confirmed = window.confirm(
+      `Da li ste sigurni da želite da obrišete primaoca "${recipient.name}"?`
+    );
+
     if (!confirmed) return;
 
     setDeletingId(recipient.id);
+
     try {
       await paymentRecipientService.delete(recipient.id);
-      toast.success('Primaoc je obrisan.');
+      toast.success('Primalac je obrisan.');
+
+      if (editingRecipientId === recipient.id) {
+        cancelEdit();
+      }
+
       await loadRecipients();
     } catch {
       toast.error('Brisanje primaoca nije uspelo.');
@@ -133,9 +207,10 @@ export default function RecipientsPage() {
 
   return (
     <div className="container mx-auto py-6 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <h1 className="text-3xl font-bold">Primaoci plaćanja</h1>
-        <Button onClick={() => setShowCreateForm((prev) => !prev)}>
+
+        <Button onClick={handleToggleCreateForm}>
           {showCreateForm ? 'Zatvori formu' : 'Dodaj primaoca'}
         </Button>
       </div>
@@ -145,28 +220,67 @@ export default function RecipientsPage() {
           <CardHeader>
             <CardTitle>Novi primalac</CardTitle>
           </CardHeader>
+
           <CardContent>
-            <form className="grid gap-4 md:grid-cols-2" onSubmit={createForm.handleSubmit(onCreate)} noValidate>
+            <form
+              className="grid gap-4 md:grid-cols-2"
+              onSubmit={createForm.handleSubmit(handleCreate)}
+              noValidate
+            >
               <div className="space-y-2">
                 <Label htmlFor="create-name">Ime</Label>
-                <Input id="create-name" {...createForm.register('name')} />
-                {createForm.formState.errors.name && <p className="text-sm text-destructive">{createForm.formState.errors.name.message}</p>}
+                <Input
+                  id="create-name"
+                  placeholder="Unesite ime primaoca"
+                  {...createForm.register('name')}
+                  disabled={creating}
+                />
+                {createForm.formState.errors.name && (
+                  <p className="text-sm text-destructive">
+                    {createForm.formState.errors.name.message}
+                  </p>
+                )}
               </div>
+
               <div className="space-y-2">
                 <Label htmlFor="create-account">Broj računa</Label>
-                <Input id="create-account" {...createForm.register('accountNumber')} />
-                {createForm.formState.errors.accountNumber && <p className="text-sm text-destructive">{createForm.formState.errors.accountNumber.message}</p>}
+                <Input
+                  id="create-account"
+                  placeholder="Unesite broj računa"
+                  {...createForm.register('accountNumber')}
+                  disabled={creating}
+                />
+                {createForm.formState.errors.accountNumber && (
+                  <p className="text-sm text-destructive">
+                    {createForm.formState.errors.accountNumber.message}
+                  </p>
+                )}
               </div>
+
               <div className="space-y-2">
                 <Label htmlFor="create-address">Adresa</Label>
-                <Input id="create-address" {...createForm.register('address')} />
+                <Input
+                  id="create-address"
+                  placeholder="Unesite adresu"
+                  {...createForm.register('address')}
+                  disabled={creating}
+                />
               </div>
+
               <div className="space-y-2">
                 <Label htmlFor="create-phone">Telefon</Label>
-                <Input id="create-phone" {...createForm.register('phoneNumber')} />
+                <Input
+                  id="create-phone"
+                  placeholder="Unesite telefon"
+                  {...createForm.register('phoneNumber')}
+                  disabled={creating}
+                />
               </div>
+
               <div className="md:col-span-2 flex justify-end">
-                <Button type="submit">Sačuvaj primaoca</Button>
+                <Button type="submit" disabled={creating}>
+                  {creating ? 'Čuvanje...' : 'Sačuvaj primaoca'}
+                </Button>
               </div>
             </form>
           </CardContent>
@@ -177,9 +291,10 @@ export default function RecipientsPage() {
         <CardHeader>
           <CardTitle>Sačuvani primaoci</CardTitle>
         </CardHeader>
+
         <CardContent className="space-y-4">
           <Input
-            placeholder="Pretraga po imenu primaoca"
+            placeholder="Pretraga po imenu, računu, adresi ili telefonu"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -187,7 +302,11 @@ export default function RecipientsPage() {
           {loading ? (
             <p className="text-muted-foreground">Učitavanje primalaca...</p>
           ) : filteredRecipients.length === 0 ? (
-            <p className="text-muted-foreground">Nemate sačuvanih primalaca.</p>
+            <p className="text-muted-foreground">
+              {searchTerm.trim()
+                ? 'Nema primalaca koji odgovaraju pretrazi.'
+                : 'Nemate sačuvanih primalaca.'}
+            </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -200,69 +319,125 @@ export default function RecipientsPage() {
                     <th className="text-left py-2">Akcije</th>
                   </tr>
                 </thead>
+
                 <tbody>
-                  {filteredRecipients.map((recipient) => (
-                    <tr key={recipient.id} className="border-b">
-                      <td className="py-2">{recipient.name}</td>
-                      <td className="py-2">{recipient.accountNumber}</td>
-                      <td className="py-2">{recipient.address || '-'}</td>
-                      <td className="py-2">{recipient.phoneNumber || '-'}</td>
-                      <td className="py-2">
-                        <div className="flex gap-2">
-                          <Button variant="outline" size="sm" onClick={() => startEdit(recipient)}>Izmeni</Button>
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => onDelete(recipient)}
-                            disabled={deletingId === recipient.id}
-                          >
-                            Obriši
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
+                  {filteredRecipients.map((recipient) => {
+                    const isEditing = editingRecipientId === recipient.id;
+                    const isDeleting = deletingId === recipient.id;
+
+                    if (isEditing) {
+                      return (
+                        <tr key={recipient.id} className="border-b bg-muted/20">
+                          <td className="py-2 align-top">
+                            <Input
+                              id={`edit-name-${recipient.id}`}
+                              placeholder="Ime"
+                              {...editForm.register('name')}
+                              disabled={updating}
+                            />
+                            {editForm.formState.errors.name && (
+                              <p className="mt-1 text-sm text-destructive">
+                                {editForm.formState.errors.name.message}
+                              </p>
+                            )}
+                          </td>
+
+                          <td className="py-2 align-top">
+                            <Input
+                              id={`edit-account-${recipient.id}`}
+                              placeholder="Broj računa"
+                              {...editForm.register('accountNumber')}
+                              disabled={updating}
+                            />
+                            {editForm.formState.errors.accountNumber && (
+                              <p className="mt-1 text-sm text-destructive">
+                                {editForm.formState.errors.accountNumber.message}
+                              </p>
+                            )}
+                          </td>
+
+                          <td className="py-2 align-top">
+                            <Input
+                              id={`edit-address-${recipient.id}`}
+                              placeholder="Adresa"
+                              {...editForm.register('address')}
+                              disabled={updating}
+                            />
+                          </td>
+
+                          <td className="py-2 align-top">
+                            <Input
+                              id={`edit-phone-${recipient.id}`}
+                              placeholder="Telefon"
+                              {...editForm.register('phoneNumber')}
+                              disabled={updating}
+                            />
+                          </td>
+
+                          <td className="py-2 align-top">
+                            <div className="flex gap-2">
+                              <Button
+                                type="button"
+                                size="sm"
+                                onClick={editForm.handleSubmit(handleEdit)}
+                                disabled={updating}
+                              >
+                                {updating ? 'Čuvanje...' : 'Sačuvaj'}
+                              </Button>
+
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={cancelEdit}
+                                disabled={updating}
+                              >
+                                Otkaži
+                              </Button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    }
+
+                    return (
+                      <tr key={recipient.id} className="border-b">
+                        <td className="py-2">{recipient.name}</td>
+                        <td className="py-2">{recipient.accountNumber}</td>
+                        <td className="py-2">{recipient.address || '-'}</td>
+                        <td className="py-2">{recipient.phoneNumber || '-'}</td>
+                        <td className="py-2">
+                          <div className="flex gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => startEdit(recipient)}
+                              disabled={isDeleting}
+                            >
+                              Izmeni
+                            </Button>
+
+                            <Button
+                              type="button"
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => handleDelete(recipient)}
+                              disabled={isDeleting}
+                            >
+                              {isDeleting ? 'Brisanje...' : 'Obriši'}
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
           )}
         </CardContent>
       </Card>
-
-      {editingRecipient && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Izmena primaoca</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form className="grid gap-4 md:grid-cols-2" onSubmit={editForm.handleSubmit(onEdit)} noValidate>
-              <div className="space-y-2">
-                <Label htmlFor="edit-name">Ime</Label>
-                <Input id="edit-name" {...editForm.register('name')} />
-                {editForm.formState.errors.name && <p className="text-sm text-destructive">{editForm.formState.errors.name.message}</p>}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-account">Broj računa</Label>
-                <Input id="edit-account" {...editForm.register('accountNumber')} />
-                {editForm.formState.errors.accountNumber && <p className="text-sm text-destructive">{editForm.formState.errors.accountNumber.message}</p>}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-address">Adresa</Label>
-                <Input id="edit-address" {...editForm.register('address')} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-phone">Telefon</Label>
-                <Input id="edit-phone" {...editForm.register('phoneNumber')} />
-              </div>
-              <div className="md:col-span-2 flex justify-end gap-2">
-                <Button type="button" variant="outline" onClick={() => setEditingRecipient(null)}>Otkaži</Button>
-                <Button type="submit">Sačuvaj izmene</Button>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
-      )}
     </div>
   );
 }
-


### PR DESCRIPTION
## Notes
- Implemented `RecipientsPage` for managing saved payment recipients.
- Page loads recipients through `paymentRecipientService.getAll()` and displays loading, empty, and filtered states.
- Added full CRUD support:
  - create recipient with validated form
  - inline edit for existing recipients
  - delete recipient with confirmation dialog
- Search supports filtering by recipient name, account number, address, and phone number.
- Form validation is handled with `react-hook-form` + `zodResolver` using `createRecipientSchema` and `editRecipientSchema`.
- Create/edit flows trim input values before sending them to the service.
- UI includes dedicated pending states for create, update, and delete actions.
- If a recipient is deleted while being edited, edit mode is cleared automatically.

## E2E Notes
- Added Cypress E2E coverage for:
  - page render and recipients list loading
  - empty state
  - search/filter behavior
  - open/close create form
  - create success and validation flow
  - create error handling
  - inline edit flow
  - edit validation and error handling
  - delete success, cancel, and error flows
  - loading state
- Tests use mocked `/recipients` API responses to avoid dependency on backend state.
- SPA routing in Cypress is handled by entering through `/home` and then switching route to `/payments/recipients`, since direct deep-link visit is not served as HTML in local environment.