### PR TITLE
FE2-05: Implement internal transfer form, full Cypress E2E coverage

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   allowCypressEnv: false,
 
   e2e: {
-    baseUrl: 'http://localhost:5173',
+    baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/transfer-page.cy.ts
+++ b/cypress/e2e/transfer-page.cy.ts
@@ -1,0 +1,642 @@
+describe('Transfer Page', () => {
+  const userEmail = 'marko.petrovic@banka.rs';
+  const userPassword = 'Admin12345';
+
+  const accountRsd1 = {
+    id: 1,
+    accountNumber: '160123456789012345',
+    ownerName: 'Marko Petrovic',
+    accountType: 'TEKUCI',
+    currency: 'RSD',
+    balance: 150000,
+    availableBalance: 120000,
+    reservedBalance: 30000,
+    dailyLimit: 300000,
+    monthlyLimit: 1000000,
+    dailySpending: 0,
+    monthlySpending: 0,
+    maintenanceFee: 0,
+    status: 'ACTIVE',
+    createdAt: '2025-01-01T10:00:00Z',
+    name: 'Glavni tekući',
+  };
+
+  const accountRsd2 = {
+    id: 2,
+    accountNumber: '205987654321000011',
+    ownerName: 'Marko Petrovic',
+    accountType: 'TEKUCI',
+    currency: 'RSD',
+    balance: 50000,
+    availableBalance: 50000,
+    reservedBalance: 0,
+    dailyLimit: 300000,
+    monthlyLimit: 1000000,
+    dailySpending: 0,
+    monthlySpending: 0,
+    maintenanceFee: 0,
+    status: 'ACTIVE',
+    createdAt: '2025-01-01T10:00:00Z',
+    name: 'Štedni RSD',
+  };
+
+  const accountEur = {
+    id: 3,
+    accountNumber: '340555666777888900',
+    ownerName: 'Marko Petrovic',
+    accountType: 'DEVIZNI',
+    currency: 'EUR',
+    balance: 1000,
+    availableBalance: 1000,
+    reservedBalance: 0,
+    dailyLimit: 5000,
+    monthlyLimit: 20000,
+    dailySpending: 0,
+    monthlySpending: 0,
+    maintenanceFee: 0,
+    status: 'ACTIVE',
+    createdAt: '2025-01-01T10:00:00Z',
+    name: 'Devizni EUR',
+  };
+
+  const allAccounts = [accountRsd1, accountRsd2, accountEur];
+
+  const loginViaUi = () => {
+    cy.session([userEmail, userPassword], () => {
+      cy.visit('/login');
+
+      cy.get('#email').should('be.visible').clear().type(userEmail);
+      cy.get('#password')
+        .should('be.visible')
+        .clear()
+        .type(userPassword, { log: false });
+
+      cy.contains('button', 'Prijavi se').click();
+      cy.url().should('include', '/home');
+    });
+  };
+
+  const mockMyAccounts = (body = allAccounts) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/accounts/my',
+      },
+      {
+        statusCode: 200,
+        body,
+      }
+    ).as('getMyAccounts');
+  };
+
+  const mockExchangeRate = (middleRate = 117.25) => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/exchange-rates/RSD/EUR',
+      },
+      {
+        statusCode: 200,
+        body: {
+          currency: 'EUR',
+          buyRate: middleRate - 0.5,
+          sellRate: middleRate + 0.5,
+          middleRate,
+          date: '2026-03-14',
+        },
+      }
+    ).as('getRateRsdEur');
+  };
+
+  const mockCreateTransfer = () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/transactions/transfer',
+      },
+      (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 987,
+            fromAccountNumber: req.body.fromAccountNumber,
+            toAccountNumber: req.body.toAccountNumber,
+            amount: req.body.amount,
+            fromCurrency: 'RSD',
+            toCurrency: 'RSD',
+            status: 'PENDING',
+            createdAt: '2026-03-14T12:00:00Z',
+          },
+        });
+      }
+    ).as('createTransfer');
+  };
+
+  const mockVerifySuccess = () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/transactions/payment/verify',
+      },
+      {
+        statusCode: 200,
+        body: {
+          success: true,
+        },
+      }
+    ).as('verifyPayment');
+  };
+
+  const mockVerifyError = () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/transactions/payment/verify',
+      },
+      {
+        statusCode: 400,
+        body: {
+          message: 'Kod nije validan. Pokušajte ponovo.',
+        },
+      }
+    ).as('verifyPaymentError');
+  };
+
+  const visitTransferPage = (query = '') => {
+    cy.visit('/home');
+
+    cy.window().then((win) => {
+      win.history.pushState({}, '', `/transfers${query}`);
+      win.dispatchEvent(new win.PopStateEvent('popstate'));
+    });
+  };
+
+  const fillValidSameCurrencyTransfer = () => {
+    cy.get('#fromAccount').select(accountRsd1.accountNumber);
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('500');
+  };
+
+  const assertVerificationModalVisible = () => {
+    cy.contains('Verifikacija transakcije').should('be.visible');
+    cy.contains('Unesite kod sa mobilne potvrde.').should('be.visible');
+    cy.get('#otp').should('be.visible');
+    cy.contains('Kod važi još:').should('be.visible');
+    cy.contains('Preostalo pokušaja:').should('be.visible');
+    cy.contains('button', 'Otkaži').should('be.visible');
+    cy.contains('button', 'Potvrdi').should('be.visible');
+  };
+
+  beforeEach(() => {
+    mockMyAccounts();
+    mockCreateTransfer();
+    loginViaUi();
+  });
+
+  it('renders page and loads available accounts', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.contains('h1', 'Prenos između računa').should('be.visible');
+    cy.contains('Novi prenos').should('be.visible');
+
+    cy.get('#fromAccount').should('exist');
+    cy.get('#toAccount').should('exist');
+    cy.get('#amount').should('exist');
+    cy.contains('button', 'Nastavi na verifikaciju').should('be.visible');
+
+    cy.get('#fromAccount').should('have.value', accountRsd1.accountNumber);
+
+    cy.contains(
+      `Raspoloživo stanje: ${Number(accountRsd1.availableBalance).toFixed(2)} ${accountRsd1.currency}`
+    ).should('be.visible');
+  });
+
+  it('shows loading state while accounts are loading', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/accounts/my',
+      },
+      {
+        delay: 1200,
+        statusCode: 200,
+        body: allAccounts,
+      }
+    ).as('getMyAccountsDelayed');
+
+    visitTransferPage();
+
+    cy.contains('Učitavanje računa...', { timeout: 3000 }).should('be.visible');
+    cy.wait('@getMyAccountsDelayed');
+    cy.contains('Učitavanje računa...').should('not.exist');
+  });
+
+  it('shows empty state when there are no available accounts', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/accounts/my',
+      },
+      {
+        statusCode: 200,
+        body: [],
+      }
+    ).as('getMyAccountsEmpty');
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccountsEmpty');
+    cy.contains('Nemate dostupnih računa za prenos.').should('be.visible');
+    cy.get('form').should('not.exist');
+  });
+
+  it('handles account loading error gracefully', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/accounts/my',
+      },
+      {
+        statusCode: 500,
+        body: { message: 'Neuspešno učitavanje računa.' },
+      }
+    ).as('getMyAccountsError');
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccountsError');
+    cy.contains('Nemate dostupnih računa za prenos.').should('be.visible');
+  });
+
+  it('uses preselected sender account from query parameter when valid', () => {
+    visitTransferPage(`?from=${accountRsd2.accountNumber}`);
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').should('have.value', accountRsd2.accountNumber);
+    cy.contains(
+      `Raspoloživo stanje: ${Number(accountRsd2.availableBalance).toFixed(2)} ${accountRsd2.currency}`
+    ).should('be.visible');
+  });
+
+  it('falls back to first account when query preselected sender is invalid', () => {
+    visitTransferPage('?from=999999999999999999');
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').should('have.value', accountRsd1.accountNumber);
+  });
+
+  it('shows only other accounts as recipient options', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').should('have.value', accountRsd1.accountNumber);
+
+    cy.get('#toAccount')
+      .find('option')
+      .then(($options) => {
+        const values = [...$options].map((opt) => (opt as HTMLOptionElement).value);
+
+        expect(values).to.not.include(accountRsd1.accountNumber);
+        expect(values).to.include(accountRsd2.accountNumber);
+        expect(values).to.include(accountEur.accountNumber);
+      });
+  });
+
+  it('updates sender balance info when sender account changes', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').select(accountEur.accountNumber);
+
+    cy.contains(
+      `Raspoloživo stanje: ${Number(accountEur.availableBalance).toFixed(2)} ${accountEur.currency}`
+    ).should('be.visible');
+  });
+
+  it('resets recipient account when it becomes equal to sender account', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#toAccount').should('have.value', accountRsd2.accountNumber);
+
+    cy.get('#fromAccount').select(accountRsd2.accountNumber);
+
+    cy.get('#toAccount').should('have.value', '');
+  });
+
+  it('shows validation errors when submitting with incomplete form', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#amount').clear();
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.get('.text-destructive').should('have.length.at.least', 1);
+    cy.get('@createTransfer.all').should('have.length', 0);
+  });
+
+  it('shows insufficient funds warning when amount exceeds available balance', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('200000');
+
+    cy.contains('Nemate dovoljno raspoloživih sredstava na računu pošiljaoca.').should(
+      'be.visible'
+    );
+  });
+
+  it('does not submit transfer when funds are insufficient', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('200000');
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.get('@createTransfer.all').should('have.length', 0);
+  });
+
+  it('shows preview without conversion for same-currency transfer', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('1500');
+
+    cy.contains('Prenos bez konverzije: 1500.00 RSD').should('be.visible');
+  });
+
+  it('shows exchange preview for transfer between different currencies', () => {
+    mockExchangeRate(117.25);
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountEur.accountNumber);
+    cy.get('#amount').clear().type('100');
+
+    cy.wait('@getRateRsdEur');
+
+    cy.contains('Kurs: 1 RSD = 117.2500 EUR').should('be.visible');
+    cy.contains('Konvertovani iznos: 11725.00 EUR').should('be.visible');
+  });
+
+  it('hides exchange preview when exchange rate request fails', () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/exchange-rates/RSD/EUR',
+      },
+      {
+        statusCode: 500,
+        body: { message: 'Rate failed' },
+      }
+    ).as('getRateError');
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountEur.accountNumber);
+    cy.get('#amount').clear().type('100');
+
+    cy.wait('@getRateError');
+
+    cy.contains('Kurs:').should('not.exist');
+    cy.contains('Konvertovani iznos:').should('not.exist');
+  });
+
+  it('does not request exchange rate when currencies are the same', () => {
+    mockExchangeRate(117.25);
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('1000');
+
+    cy.get('@getRateRsdEur.all').should('have.length', 0);
+    cy.contains('Prenos bez konverzije: 1000.00 RSD').should('be.visible');
+  });
+
+  it('does not request exchange rate when amount is zero', () => {
+    mockExchangeRate(117.25);
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountEur.accountNumber);
+    cy.get('#amount').clear().type('0');
+
+    cy.get('@getRateRsdEur.all').should('have.length', 0);
+    cy.contains('Kurs:').should('not.exist');
+    cy.contains('Konvertovani iznos:').should('not.exist');
+  });
+
+  it('creates transfer successfully with integer amount', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').select(accountRsd1.accountNumber);
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('2500');
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer')
+      .its('request.body')
+      .should('deep.equal', {
+        fromAccountNumber: accountRsd1.accountNumber,
+        toAccountNumber: accountRsd2.accountNumber,
+        amount: 2500,
+      });
+  });
+
+  it('creates transfer successfully with decimal amount', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#fromAccount').select(accountRsd1.accountNumber);
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('1234.56');
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer')
+      .its('request.body')
+      .should('deep.equal', {
+        fromAccountNumber: accountRsd1.accountNumber,
+        toAccountNumber: accountRsd2.accountNumber,
+        amount: 1234.56,
+      });
+  });
+
+  it('opens verification modal after successful transfer creation', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    fillValidSameCurrencyTransfer();
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer');
+    assertVerificationModalVisible();
+  });
+
+  it('closes verification modal when user cancels it', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    fillValidSameCurrencyTransfer();
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer');
+    assertVerificationModalVisible();
+
+    cy.contains('button', 'Otkaži').click();
+
+    cy.contains('Verifikacija transakcije').should('not.exist');
+    cy.get('#otp').should('not.exist');
+  });
+
+  it('verifies transfer successfully through verification modal', () => {
+    mockVerifySuccess();
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    fillValidSameCurrencyTransfer();
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer');
+    assertVerificationModalVisible();
+
+    cy.get('#otp').clear().type('123456');
+    cy.contains('button', 'Potvrdi').click();
+
+    cy.wait('@verifyPayment')
+      .its('request.body')
+      .should('deep.equal', {
+        transactionId: 987,
+        code: '123456',
+      });
+  });
+
+  it('shows verification error when OTP code is invalid', () => {
+    mockVerifyError();
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    fillValidSameCurrencyTransfer();
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransfer');
+    assertVerificationModalVisible();
+
+    cy.get('#otp').clear().type('111111');
+    cy.contains('button', 'Potvrdi').click();
+
+    cy.wait('@verifyPaymentError');
+    cy.contains('Kod nije validan. Pokušajte ponovo.').should('be.visible');
+    cy.contains('Preostalo pokušaja:').should('be.visible');
+  });
+
+  it('disables form controls while transfer request is in progress', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/transactions/transfer',
+      },
+      {
+        delay: 1200,
+        statusCode: 200,
+        body: {
+          id: 987,
+          fromAccountNumber: accountRsd1.accountNumber,
+          toAccountNumber: accountRsd2.accountNumber,
+          amount: 500,
+          fromCurrency: 'RSD',
+          toCurrency: 'RSD',
+          status: 'PENDING',
+          createdAt: '2026-03-14T12:00:00Z',
+        },
+      }
+    ).as('createTransferDelayed');
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('500');
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.contains('button', 'Kreiranje...').should('be.visible');
+    cy.get('#fromAccount').should('be.disabled');
+    cy.get('#toAccount').should('be.disabled');
+    cy.get('#amount').should('be.disabled');
+
+    cy.wait('@createTransferDelayed');
+  });
+
+  it('handles transfer creation error gracefully with backend message', () => {
+    cy.intercept(
+      {
+        method: 'POST',
+        pathname: '/transactions/transfer',
+      },
+      {
+        statusCode: 400,
+        body: { message: 'Prenos nije dozvoljen za izabrane račune' },
+      }
+    ).as('createTransferError');
+
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.get('#toAccount').select(accountRsd2.accountNumber);
+    cy.get('#amount').clear().type('500');
+
+    cy.contains('button', 'Nastavi na verifikaciju').click();
+
+    cy.wait('@createTransferError');
+  });
+
+  it('keeps submit button enabled in normal ready state', () => {
+    visitTransferPage();
+
+    cy.wait('@getMyAccounts');
+
+    cy.contains('button', 'Nastavi na verifikaciju').should('not.be.disabled');
+  });
+});

--- a/src/pages/Transfers/TransferPage.tsx
+++ b/src/pages/Transfers/TransferPage.tsx
@@ -1,5 +1,3 @@
-// TODO [FE2-05a] @Elena - Prenosi: Forma za prenos izmedju racuna
-// TODO [FE2-05b] @Elena - Prenosi: Verifikacija prenosa
 // TODO [FE2-08a] @Antonije - Transferi: Kreiranje transfera
 // TODO [FE2-08b] @Antonije - Transferi: Istorija i prikaz kursa/provizije
 //
@@ -36,22 +34,47 @@ function formatAmount(value: number | null | undefined, decimals = 2): string {
   return Number.isFinite(num) ? num.toFixed(decimals) : (0).toFixed(decimals);
 }
 
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as { response?: unknown }).response === 'object' &&
+    (error as { response?: unknown }).response !== null
+  ) {
+    const response = (error as { response?: { data?: { message?: string } } }).response;
+    if (response?.data?.message) {
+      return response.data.message;
+    }
+  }
+
+  return fallback;
+}
+
 export default function TransferPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+
   const preselectedFrom = searchParams.get('from') || '';
+
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
   const [showVerification, setShowVerification] = useState(false);
   const [pendingTransactionId, setPendingTransactionId] = useState<number | null>(null);
-  const [exchangePreview, setExchangePreview] = useState<{ rate: number; convertedAmount: number } | null>(null);
+
+  const [exchangePreview, setExchangePreview] = useState<{
+    rate: number;
+    convertedAmount: number;
+  } | null>(null);
 
   const {
     register,
     handleSubmit,
     watch,
     setValue,
+    reset,
     formState: { errors },
   } = useForm<TransferFormData>({
     resolver: zodResolver(transferSchema),
@@ -64,30 +87,53 @@ export default function TransferPage() {
 
   useEffect(() => {
     let mounted = true;
+
     const loadAccounts = async () => {
       setIsLoading(true);
+
       try {
         const data = await accountService.getMyAccounts();
+
         if (!mounted) return;
+
         const safeAccounts = asArray<Account>(data);
         setAccounts(safeAccounts);
-        if (!preselectedFrom && safeAccounts.length > 0) {
-          setValue('fromAccountNumber', safeAccounts[0].accountNumber);
+
+        if (safeAccounts.length === 0) {
+          toast.error('Nemate dostupnih računa za prenos.');
+          return;
         }
-      } catch {
+
+        const hasPreselected = safeAccounts.some(
+          (account) => account.accountNumber === preselectedFrom
+        );
+
+        const initialFrom =
+          preselectedFrom && hasPreselected ? preselectedFrom : safeAccounts[0].accountNumber;
+
+        reset({
+          fromAccountNumber: initialFrom,
+          toAccountNumber: '',
+          amount: 0,
+        });
+      } catch (error) {
         if (!mounted) return;
-        toast.error('Neuspešno učitavanje računa.');
+
+        toast.error(getErrorMessage(error, 'Neuspešno učitavanje računa.'));
         setAccounts([]);
       } finally {
-        if (mounted) setIsLoading(false);
+        if (mounted) {
+          setIsLoading(false);
+        }
       }
     };
 
     loadAccounts();
+
     return () => {
       mounted = false;
     };
-  }, [preselectedFrom, setValue]);
+  }, [preselectedFrom, reset]);
 
   const fromAccount = watch('fromAccountNumber');
   const toAccount = watch('toAccountNumber');
@@ -99,17 +145,26 @@ export default function TransferPage() {
     () => safeAccounts.find((account) => account.accountNumber === fromAccount),
     [safeAccounts, fromAccount]
   );
-  const toAccountData = useMemo(
-    () => safeAccounts.find((account) => account.accountNumber === toAccount),
-    [safeAccounts, toAccount]
-  );
 
   const toAccountOptions = useMemo(
     () => safeAccounts.filter((account) => account.accountNumber !== fromAccount),
     [safeAccounts, fromAccount]
   );
 
+  const toAccountData = useMemo(
+    () => toAccountOptions.find((account) => account.accountNumber === toAccount),
+    [toAccountOptions, toAccount]
+  );
+
   useEffect(() => {
+    if (toAccount && toAccount === fromAccount) {
+      setValue('toAccountNumber', '');
+    }
+  }, [fromAccount, toAccount, setValue]);
+
+  useEffect(() => {
+    let cancelled = false;
+
     if (!fromAccountData || !toAccountData || !amount || amount <= 0) {
       setExchangePreview(null);
       return;
@@ -122,45 +177,104 @@ export default function TransferPage() {
 
     const loadRate = async () => {
       try {
-        const rate = await currencyService.getRate(fromAccountData.currency, toAccountData.currency);
+        const rate = await currencyService.getRate(
+          fromAccountData.currency,
+          toAccountData.currency
+        );
+
+        if (cancelled) return;
+
         setExchangePreview({
           rate: rate.middleRate,
           convertedAmount: amount * rate.middleRate,
         });
       } catch {
+        if (cancelled) return;
         setExchangePreview(null);
       }
     };
 
     loadRate();
+
+    return () => {
+      cancelled = true;
+    };
   }, [amount, fromAccountData, toAccountData]);
 
+  const insufficientFunds = useMemo(() => {
+    if (!fromAccountData) return false;
+    return amount > 0 && Number(fromAccountData.availableBalance ?? 0) < Number(amount);
+  }, [fromAccountData, amount]);
+
   const onSubmit = async (data: TransferFormData) => {
+    if (!fromAccountData) {
+      toast.error('Izaberite račun pošiljaoca.');
+      return;
+    }
+
+    if (!toAccountData) {
+      toast.error('Izaberite račun primaoca.');
+      return;
+    }
+
+    if (data.fromAccountNumber === data.toAccountNumber) {
+      toast.error('Račun pošiljaoca i primaoca ne mogu biti isti.');
+      return;
+    }
+
+    if (Number(data.amount) <= 0) {
+      toast.error('Iznos mora biti veći od nule.');
+      return;
+    }
+
+    if (insufficientFunds) {
+      toast.error('Nemate dovoljno raspoloživih sredstava na izabranom računu.');
+      return;
+    }
+
     setIsSubmitting(true);
+
     try {
-      const transfer = await transactionService.createTransfer(data);
+      const transfer = await transactionService.createTransfer({
+        fromAccountNumber: data.fromAccountNumber,
+        toAccountNumber: data.toAccountNumber,
+        amount: Number(data.amount),
+      });
+
       setPendingTransactionId(transfer.id);
       setShowVerification(true);
       toast.info('Prenos je kreiran. Potrebna je verifikacija.');
-    } catch (err: unknown) {
-      const error = err as { response?: { data?: { message?: string } } };
-      toast.error(error.response?.data?.message || 'Kreiranje prenosa nije uspelo.');
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, 'Kreiranje prenosa nije uspelo.'));
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleVerificationClose = () => {
+    setShowVerification(false);
+  };
+
+  const handleVerificationSuccess = () => {
+    setShowVerification(false);
+    toast.success('Prenos je uspešno verifikovan.');
+    navigate('/accounts');
+  };
+
   return (
-    <div className="container mx-auto py-6 max-w-2xl">
-      <h1 className="text-3xl font-bold mb-6">Prenos između računa</h1>
+    <div className="container mx-auto max-w-2xl py-6">
+      <h1 className="mb-6 text-3xl font-bold">Prenos između računa</h1>
 
       <Card>
         <CardHeader>
           <CardTitle>Novi prenos</CardTitle>
         </CardHeader>
+
         <CardContent>
           {isLoading ? (
             <p className="text-muted-foreground">Učitavanje računa...</p>
+          ) : safeAccounts.length === 0 ? (
+            <p className="text-muted-foreground">Nemate dostupnih računa za prenos.</p>
           ) : (
             <form className="space-y-4" onSubmit={handleSubmit(onSubmit)} noValidate>
               <div className="space-y-2">
@@ -170,16 +284,31 @@ export default function TransferPage() {
                   title="Račun pošiljaoca"
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                   {...register('fromAccountNumber')}
+                  disabled={isSubmitting}
                 >
                   <option value="">Izaberite račun</option>
                   {safeAccounts.map((account) => (
                     <option key={account.id} value={account.accountNumber}>
-                      {account.accountNumber} | {formatAmount(account.availableBalance)} {account.currency}
+                      {account.accountNumber} | {formatAmount(account.availableBalance)}{' '}
+                      {account.currency}
                     </option>
                   ))}
                 </select>
-                {errors.fromAccountNumber && <p className="text-sm text-destructive">{errors.fromAccountNumber.message}</p>}
+                {errors.fromAccountNumber && (
+                  <p className="text-sm text-destructive">
+                    {errors.fromAccountNumber.message}
+                  </p>
+                )}
               </div>
+
+              {fromAccountData && (
+                <div className="rounded-md border p-3 text-sm">
+                  <p>
+                    Raspoloživo stanje: {formatAmount(fromAccountData.availableBalance)}{' '}
+                    {fromAccountData.currency}
+                  </p>
+                </div>
+              )}
 
               <div className="space-y-2">
                 <Label htmlFor="toAccount">Račun primaoca</Label>
@@ -188,36 +317,69 @@ export default function TransferPage() {
                   title="Račun primaoca"
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                   {...register('toAccountNumber')}
+                  disabled={isSubmitting}
                 >
                   <option value="">Izaberite račun</option>
                   {toAccountOptions.map((account) => (
                     <option key={account.id} value={account.accountNumber}>
-                      {account.accountNumber} | {formatAmount(account.availableBalance)} {account.currency}
+                      {account.accountNumber} | {formatAmount(account.availableBalance)}{' '}
+                      {account.currency}
                     </option>
                   ))}
                 </select>
-                {errors.toAccountNumber && <p className="text-sm text-destructive">{errors.toAccountNumber.message}</p>}
+                {errors.toAccountNumber && (
+                  <p className="text-sm text-destructive">
+                    {errors.toAccountNumber.message}
+                  </p>
+                )}
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="amount">Iznos</Label>
-                <Input id="amount" type="number" step="0.01" {...register('amount', { valueAsNumber: true })} />
-                {errors.amount && <p className="text-sm text-destructive">{errors.amount.message}</p>}
+                <Input
+                  id="amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  {...register('amount', { valueAsNumber: true })}
+                  disabled={isSubmitting}
+                />
+                {errors.amount && (
+                  <p className="text-sm text-destructive">{errors.amount.message}</p>
+                )}
+                {insufficientFunds && (
+                  <p className="text-sm text-destructive">
+                    Nemate dovoljno raspoloživih sredstava na računu pošiljaoca.
+                  </p>
+                )}
               </div>
 
               {exchangePreview && fromAccountData && toAccountData && (
-                <div className="rounded-md border p-3 text-sm space-y-1">
+                <div className="space-y-1 rounded-md border p-3 text-sm">
                   <p>
-                    Kurs: 1 {fromAccountData.currency} = {formatAmount(exchangePreview.rate, 4)} {toAccountData.currency}
+                    Kurs: 1 {fromAccountData.currency} = {formatAmount(exchangePreview.rate, 4)}{' '}
+                    {toAccountData.currency}
                   </p>
                   <p>
-                    Konvertovani iznos: {formatAmount(exchangePreview.convertedAmount)} {toAccountData.currency}
+                    Konvertovani iznos: {formatAmount(exchangePreview.convertedAmount)}{' '}
+                    {toAccountData.currency}
                   </p>
                 </div>
               )}
 
+              {fromAccountData &&
+                toAccountData &&
+                fromAccountData.currency === toAccountData.currency &&
+                amount > 0 && (
+                  <div className="space-y-1 rounded-md border p-3 text-sm">
+                    <p>
+                      Prenos bez konverzije: {formatAmount(amount)} {fromAccountData.currency}
+                    </p>
+                  </div>
+                )}
+
               <div className="flex justify-end">
-                <Button type="submit" disabled={isSubmitting}>
+                <Button type="submit" disabled={isSubmitting || isLoading}>
                   {isSubmitting ? 'Kreiranje...' : 'Nastavi na verifikaciju'}
                 </Button>
               </div>
@@ -229,13 +391,9 @@ export default function TransferPage() {
       <VerificationModal
         transactionId={pendingTransactionId}
         isOpen={showVerification}
-        onClose={() => setShowVerification(false)}
-        onSuccess={() => {
-          setShowVerification(false);
-          navigate('/accounts');
-        }}
+        onClose={handleVerificationClose}
+        onSuccess={handleVerificationSuccess}
       />
     </div>
   );
 }
-


### PR DESCRIPTION
## FE2-05 – Internal Transfers

This PR implements the internal account transfer functionality and adds comprehensive Cypress E2E tests.

### Implemented features

**Transfer form**
- Select sender account
- Select recipient account
- Enter transfer amount
- Prevent selecting the same account for sender and recipient
- Validate transfer amount
- Prevent transfers when insufficient funds are available

**Currency conversion preview**
- Automatic exchange rate fetch when accounts use different currencies
- Display conversion rate and converted amount
- Graceful handling of exchange rate request failures

**Transfer verification**
- After creating a transfer, the verification modal is displayed
- OTP code input (4–6 digits)
- Countdown timer (5 minutes)
- Maximum 3 verification attempts
- Error handling for invalid codes
- Successful verification completes the transfer

### Cypress E2E test coverage

The following scenarios are covered:

**Page behavior**
- page rendering
- loading state
- empty accounts state
- backend error handling

**Form logic**
- sender account preselection
- recipient account filtering
- validation errors
- insufficient funds prevention

**Exchange logic**
- preview for same currency transfers
- preview for cross-currency transfers
- handling exchange rate request failures

**Transfer flow**
- transfer creation with integer and decimal amounts
- disabled form during submission
- backend error handling

**Verification flow**
- opening verification modal
- closing modal
- successful OTP verification
- invalid OTP handling

### Notes

- Backend endpoints for transfer creation and verification are mocked in Cypress tests.
- Verification endpoint used in tests: `/transactions/payment/verify`.