### PR TITLE
Add interbank OTC service wrapper, types, and unit tests

### DIFF
--- a/src/services/interbankOtcService.test.ts
+++ b/src/services/interbankOtcService.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import api from './api';
+import interbankOtcService from './interbankOtcService';
+
+vi.mock('./api');
+const mockedApi = vi.mocked(api);
+
+describe('interbankOtcService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listRemoteListings', () => {
+    it('should fetch remote listings', async () => {
+      const listings = [
+        {
+          bankCode: 'BANKA2',
+          sellerPublicId: 'remote-user-1',
+          sellerName: 'Remote Seller',
+          listingTicker: 'AAPL',
+          listingName: 'Apple Inc.',
+          listingCurrency: 'USD',
+          currentPrice: 198.25,
+          availableQuantity: 40,
+        },
+      ];
+      mockedApi.get.mockResolvedValue({ data: listings });
+
+      const result = await interbankOtcService.listRemoteListings();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/interbank/otc/listings');
+      expect(result).toEqual(listings);
+    });
+
+    it('should propagate listing fetch errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Remote listings unavailable'));
+
+      await expect(interbankOtcService.listRemoteListings()).rejects.toThrow('Remote listings unavailable');
+    });
+  });
+
+  describe('createOffer', () => {
+    it('should create an inter-bank offer', async () => {
+      const request = {
+        sellerBankCode: 'BANKA2',
+        sellerUserId: 'remote-user-1',
+        listingTicker: 'AAPL',
+        quantity: 15,
+        pricePerStock: 195,
+        premium: 12.5,
+        settlementDate: '2026-06-01',
+      };
+      const created = {
+        offerId: 'offer-uuid',
+        listingTicker: 'AAPL',
+        listingName: 'Apple Inc.',
+        listingCurrency: 'USD',
+        currentPrice: 198.25,
+        buyerBankCode: 'BANKA1',
+        buyerUserId: 'client-1',
+        buyerName: 'Stefan Jovanovic',
+        sellerBankCode: 'BANKA2',
+        sellerUserId: 'remote-user-1',
+        sellerName: 'Remote Seller',
+        quantity: 15,
+        pricePerStock: 195,
+        premium: 12.5,
+        settlementDate: '2026-06-01',
+        waitingOnBankCode: 'BANKA2',
+        waitingOnUserId: 'remote-user-1',
+        myTurn: false,
+        status: 'ACTIVE' as const,
+        lastModifiedAt: '2026-04-24T10:00:00',
+        lastModifiedByName: 'Stefan Jovanovic',
+      };
+      mockedApi.post.mockResolvedValue({ data: created });
+
+      const result = await interbankOtcService.createOffer(request);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/interbank/otc/offers', request);
+      expect(result).toEqual(created);
+    });
+
+    it('should propagate create offer errors', async () => {
+      mockedApi.post.mockRejectedValue(new Error('Create failed'));
+
+      await expect(
+        interbankOtcService.createOffer({
+          sellerBankCode: 'BANKA2',
+          sellerUserId: 'remote-user-1',
+          listingTicker: 'AAPL',
+          quantity: 15,
+          pricePerStock: 195,
+          premium: 12.5,
+          settlementDate: '2026-06-01',
+        }),
+      ).rejects.toThrow('Create failed');
+    });
+  });
+
+  describe('listMyOffers', () => {
+    it('should fetch my offers', async () => {
+      const offers = [{ offerId: 'offer-uuid', status: 'ACTIVE' }];
+      mockedApi.get.mockResolvedValue({ data: offers });
+
+      const result = await interbankOtcService.listMyOffers();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/interbank/otc/offers/my');
+      expect(result).toEqual(offers);
+    });
+
+    it('should propagate offer fetch errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Offers unavailable'));
+
+      await expect(interbankOtcService.listMyOffers()).rejects.toThrow('Offers unavailable');
+    });
+  });
+
+  describe('counterOffer', () => {
+    it('should send a counter offer', async () => {
+      const request = {
+        offerId: 'offer-uuid',
+        quantity: 20,
+        pricePerStock: 193.5,
+        premium: 10,
+        settlementDate: '2026-06-03',
+      };
+      const updated = { offerId: 'offer-uuid', status: 'ACTIVE' };
+      mockedApi.patch.mockResolvedValue({ data: updated });
+
+      const result = await interbankOtcService.counterOffer('offer-uuid', request);
+
+      expect(mockedApi.patch).toHaveBeenCalledWith('/interbank/otc/offers/offer-uuid/counter', request);
+      expect(result).toEqual(updated);
+    });
+
+    it('should propagate counter offer errors', async () => {
+      mockedApi.patch.mockRejectedValue(new Error('Counter failed'));
+
+      await expect(
+        interbankOtcService.counterOffer('offer-uuid', {
+          offerId: 'offer-uuid',
+          quantity: 20,
+          pricePerStock: 193.5,
+          premium: 10,
+          settlementDate: '2026-06-03',
+        }),
+      ).rejects.toThrow('Counter failed');
+    });
+  });
+
+  describe('declineOffer', () => {
+    it('should decline an offer', async () => {
+      const declined = { offerId: 'offer-uuid', status: 'DECLINED' };
+      mockedApi.patch.mockResolvedValue({ data: declined });
+
+      const result = await interbankOtcService.declineOffer('offer-uuid');
+
+      expect(mockedApi.patch).toHaveBeenCalledWith('/interbank/otc/offers/offer-uuid/decline');
+      expect(result).toEqual(declined);
+    });
+
+    it('should propagate decline errors', async () => {
+      mockedApi.patch.mockRejectedValue(new Error('Decline failed'));
+
+      await expect(interbankOtcService.declineOffer('offer-uuid')).rejects.toThrow('Decline failed');
+    });
+  });
+
+  describe('acceptOffer', () => {
+    it('should accept an offer with accountId query param', async () => {
+      const accepted = { offerId: 'offer-uuid', status: 'ACCEPTED' };
+      mockedApi.patch.mockResolvedValue({ data: accepted });
+
+      const result = await interbankOtcService.acceptOffer('offer-uuid', 123);
+
+      expect(mockedApi.patch).toHaveBeenCalledWith('/interbank/otc/offers/offer-uuid/accept', undefined, {
+        params: { accountId: 123 },
+      });
+      expect(result).toEqual(accepted);
+    });
+
+    it('should propagate accept errors', async () => {
+      mockedApi.patch.mockRejectedValue(new Error('Accept failed'));
+
+      await expect(interbankOtcService.acceptOffer('offer-uuid', 123)).rejects.toThrow('Accept failed');
+    });
+  });
+
+  describe('listMyContracts', () => {
+    it('should fetch my contracts without filters', async () => {
+      const contracts = [{ id: 'contract-uuid', status: 'ACTIVE' }];
+      mockedApi.get.mockResolvedValue({ data: contracts });
+
+      const result = await interbankOtcService.listMyContracts();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/interbank/otc/contracts/my', {
+        params: undefined,
+      });
+      expect(result).toEqual(contracts);
+    });
+
+    it('should pass status filter when provided', async () => {
+      mockedApi.get.mockResolvedValue({ data: [] });
+
+      await interbankOtcService.listMyContracts('EXERCISED');
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/interbank/otc/contracts/my', {
+        params: { status: 'EXERCISED' },
+      });
+    });
+
+    it('should propagate contract fetch errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Contracts unavailable'));
+
+      await expect(interbankOtcService.listMyContracts()).rejects.toThrow('Contracts unavailable');
+    });
+  });
+
+  describe('exerciseContract', () => {
+    it('should exercise a contract with buyerAccountId query param', async () => {
+      const transaction = {
+        id: 55,
+        transactionId: 'tx-uuid',
+        type: 'OTC' as const,
+        status: 'INITIATED' as const,
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 2925,
+        currency: 'USD',
+        createdAt: '2026-04-24T10:00:00',
+        retryCount: 0,
+      };
+      mockedApi.post.mockResolvedValue({ data: transaction });
+
+      const result = await interbankOtcService.exerciseContract('contract-uuid', 456);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/interbank/otc/contracts/contract-uuid/exercise', undefined, {
+        params: { buyerAccountId: 456 },
+      });
+      expect(result).toEqual(transaction);
+    });
+
+    it('should propagate exercise errors', async () => {
+      mockedApi.post.mockRejectedValue(new Error('Exercise failed'));
+
+      await expect(interbankOtcService.exerciseContract('contract-uuid', 456)).rejects.toThrow('Exercise failed');
+    });
+  });
+});

--- a/src/services/interbankOtcService.ts
+++ b/src/services/interbankOtcService.ts
@@ -1,12 +1,12 @@
-// @ts-expect-error — `api` ce se koristiti kad tim implementira TODO metode.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import api from './api';
 import type {
   OtcInterbankListing,
   OtcInterbankOffer,
   CreateOtcInterbankOfferRequest,
   CounterOtcInterbankOfferRequest,
-  OtcInterbankOfferStatus,
+  OtcInterbankContractStatus,
+  OtcInterbankContract,
+  InterbankTransaction,
 } from '@/types/celina4';
 
 /*
@@ -31,44 +31,58 @@ import type {
 ================================================================================
 */
 const interbankOtcService = {
-  /** TODO — GET /interbank/otc/listings */
+  /** Lista dostupnih OTC listinga iz drugih banaka. */
   async listRemoteListings(): Promise<OtcInterbankListing[]> {
-    throw new Error('TODO');
+    const { data } = await api.get<OtcInterbankListing[]>('/interbank/otc/listings');
+    return data;
   },
 
-  /** TODO — POST /interbank/otc/offers */
-  async createOffer(_dto: CreateOtcInterbankOfferRequest): Promise<OtcInterbankOffer> {
-    throw new Error('TODO');
+  /** Kreira novu inter-bank OTC ponudu. */
+  async createOffer(dto: CreateOtcInterbankOfferRequest): Promise<OtcInterbankOffer> {
+    const { data } = await api.post<OtcInterbankOffer>('/interbank/otc/offers', dto);
+    return data;
   },
 
-  /** TODO — GET /interbank/otc/offers/my */
+  /** Moje inter-bank OTC ponude. */
   async listMyOffers(): Promise<OtcInterbankOffer[]> {
-    throw new Error('TODO');
+    const { data } = await api.get<OtcInterbankOffer[]>('/interbank/otc/offers/my');
+    return data;
   },
 
-  /** TODO — PATCH /interbank/otc/offers/{offerId}/counter */
-  async counterOffer(_offerId: string, _dto: CounterOtcInterbankOfferRequest): Promise<OtcInterbankOffer> {
-    throw new Error('TODO');
+  /** Kontraponuda na postojeći inter-bank OTC offer. */
+  async counterOffer(offerId: string, dto: CounterOtcInterbankOfferRequest): Promise<OtcInterbankOffer> {
+    const { data } = await api.patch<OtcInterbankOffer>(`/interbank/otc/offers/${offerId}/counter`, dto);
+    return data;
   },
 
-  /** TODO — PATCH /interbank/otc/offers/{offerId}/decline */
-  async declineOffer(_offerId: string): Promise<OtcInterbankOffer> {
-    throw new Error('TODO');
+  /** Odbija postojeću inter-bank OTC ponudu. */
+  async declineOffer(offerId: string): Promise<OtcInterbankOffer> {
+    const { data } = await api.patch<OtcInterbankOffer>(`/interbank/otc/offers/${offerId}/decline`);
+    return data;
   },
 
-  /** TODO — PATCH /interbank/otc/offers/{offerId}/accept?accountId=X */
-  async acceptOffer(_offerId: string, _accountId: number): Promise<OtcInterbankOffer> {
-    throw new Error('TODO');
+  /** Prihvata ponudu i prosleđuje račun sa kog se rezerviše premija. */
+  async acceptOffer(offerId: string, accountId: number): Promise<OtcInterbankOffer> {
+    const { data } = await api.patch<OtcInterbankOffer>(`/interbank/otc/offers/${offerId}/accept`, undefined, {
+      params: { accountId },
+    });
+    return data;
   },
 
-  /** TODO — GET /interbank/otc/contracts/my[?status=...] */
-  async listMyContracts(_status?: OtcInterbankOfferStatus | 'ALL'): Promise<unknown[]> {
-    throw new Error('TODO — vrati tip posle potvrde sa BE tim-om');
+  /** Moji inter-bank OTC ugovori, opciono filtrirani po statusu. */
+  async listMyContracts(status?: OtcInterbankContractStatus | 'ALL'): Promise<OtcInterbankContract[]> {
+    const { data } = await api.get<OtcInterbankContract[]>('/interbank/otc/contracts/my', {
+      params: status ? { status } : undefined,
+    });
+    return data;
   },
 
-  /** TODO — POST /interbank/otc/contracts/{contractId}/exercise?buyerAccountId=X */
-  async exerciseContract(_contractId: string, _buyerAccountId: number): Promise<unknown> {
-    throw new Error('TODO');
+  /** Pokreće SAGA exercise za postojeći inter-bank OTC ugovor. */
+  async exerciseContract(contractId: string, buyerAccountId: number): Promise<InterbankTransaction> {
+    const { data } = await api.post<InterbankTransaction>(`/interbank/otc/contracts/${contractId}/exercise`, undefined, {
+      params: { buyerAccountId },
+    });
+    return data;
   },
 };
 

--- a/src/types/celina4.ts
+++ b/src/types/celina4.ts
@@ -127,6 +127,7 @@ export interface OtcInterbankListing {
 }
 
 export type OtcInterbankOfferStatus = 'ACTIVE' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
+export type OtcInterbankContractStatus = 'ACTIVE' | 'EXERCISED' | 'EXPIRED';
 
 export interface OtcInterbankOffer {
   offerId: string; // UUID, isti kod obe banke
@@ -175,9 +176,62 @@ export interface CounterOtcInterbankOfferRequest {
   settlementDate: string;
 }
 
-// Kontrakt iz inter-bank SAGA je identican struktur-i intra-bank OtcContract,
-// dodaje se samo `buyerBankCode` / `sellerBankCode`. Za sada reuse OtcContract
-// iz celina3.ts + dva dodatna polja kada se doda.
+/**
+ * Privremeni FE tip za inter-bank OTC contract dok BE ne objavi eksplicitan
+ * DTO. Polja su izvedena iz intra-bank contract oblika + inter-bank offer
+ * identifikatora (`contractId`/user IDs kao string).
+ */
+export interface OtcInterbankContract {
+  id: string;
+  listingId: number;
+  listingTicker: string;
+  listingName: string;
+  listingCurrency: string;
+  buyerUserId: string;
+  buyerBankCode: string;
+  buyerName: string;
+  sellerUserId: string;
+  sellerBankCode: string;
+  sellerName: string;
+  quantity: number;
+  strikePrice: number;
+  premium: number;
+  currentPrice: number;
+  settlementDate: string;
+  status: OtcInterbankContractStatus;
+  createdAt: string;
+  exercisedAt?: string | null;
+}
+
+export type InterbankTransactionType = 'PAYMENT' | 'OTC';
+
+export interface InterbankTransaction {
+  id: number;
+  transactionId: string;
+  type: InterbankTransactionType;
+  status: InterbankPaymentStatus;
+  senderBankCode: string;
+  receiverBankCode: string;
+  amount?: number | null;
+  currency?: string | null;
+  convertedAmount?: number | null;
+  convertedCurrency?: string | null;
+  exchangeRate?: number | null;
+  commissionAmount?: number | null;
+  senderAccountNumber?: string | null;
+  receiverAccountNumber?: string | null;
+  reservedAmount?: number | null;
+  listingTicker?: string | null;
+  quantity?: number | null;
+  strikePrice?: number | null;
+  createdAt: string;
+  preparedAt?: string | null;
+  committedAt?: string | null;
+  abortedAt?: string | null;
+  lastRetryAt?: string | null;
+  retryCount: number;
+  failureReason?: string | null;
+}
 
 
 // ── INTER-BANK PLACANJE (Zaduzen: antonije3) ──────────────────────────────


### PR DESCRIPTION
## Description

Implemented frontend support for the OTC inter-bank flow defined in **Celina 4** for `/interbank/otc/**` endpoints.

This task covered:
- completing the FE service wrapper in `src/services/interbankOtcService.ts`
- aligning and extending OTC inter-bank types in `src/types/celina4.ts`
- adding unit test coverage for all service methods in `src/services/interbankOtcService.test.ts`

The implementation follows the existing intra-bank OTC pattern from `src/services/otcService.ts` and maps the FE layer to the backend contract described in:

- `Banka-2-Backend/banka2_bek/.../interbank/dto/OtcInterbankDtos.java`
- Celina 4 spec, lines **438-519**

---

## What Was Implemented

### Service wrapper
Completed all required methods in `src/services/interbankOtcService.ts`:

- `listRemoteListings()` → `GET /interbank/otc/listings`
- `createOffer()` → `POST /interbank/otc/offers`
- `listMyOffers()` → `GET /interbank/otc/offers/my`
- `counterOffer()` → `PATCH /interbank/otc/offers/{id}/counter`
- `declineOffer()` → `PATCH /interbank/otc/offers/{id}/decline`
- `acceptOffer()` → `PATCH /interbank/otc/offers/{id}/accept?accountId=X`
- `listMyContracts()` → `GET /interbank/otc/contracts/my`
- `exerciseContract()` → `POST /interbank/otc/contracts/{id}/exercise?buyerAccountId=X`

### Types
Updated OTC inter-bank related typings in `src/types/celina4.ts`:

- kept existing DTO-aligned types for:
  - `OtcInterbankListing`
  - `OtcInterbankOffer`
  - `CreateOtcInterbankOfferRequest`
  - `CounterOtcInterbankOfferRequest`
- added/extended supporting FE types for:
  - `OtcInterbankContractStatus`
  - `OtcInterbankContract`
  - `InterbankTransactionType`
  - `InterbankTransaction`

### Tests
Added unit tests in `src/services/interbankOtcService.test.ts` with mocked API calls for all implemented methods.

Test coverage includes:
- successful responses
- query param handling where applicable
- request payload verification
- error propagation from the API layer

---

## Backend Contract Notes

The implementation was aligned with the backend DTO file for the parts explicitly defined there:

- `OtcInterbankListingDto`
- `OtcInterbankOfferDto`
- `CreateOtcInterbankOfferDto`
- `CounterOtcInterbankOfferDto`

For contracts/exercise flow, FE typing was derived from the currently available backend context in controller/service definitions, since there is no explicit standalone inter-bank contract DTO exposed in the referenced DTO file yet.

---

## Validation

Verified locally with:

```bash
npx vitest run src/services/interbankOtcService.test.ts
npx tsc -p tsconfig.app.json --noEmit
npx eslint src/services/interbankOtcService.ts src/types/celina4.ts src/services/interbankOtcService.test.ts
```

Results:
- `17/17` tests passed
- TypeScript: clean
- ESLint: clean