### PR TITLE
feat(funds): FundDetailsPage — KPI karte, hartije tabela, performance grafikon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,10 @@ import SupervisorDashboardPage from './pages/Employee/SupervisorDashboardPage';
 import OtcTrgovinaPage from './pages/Otc/OtcTrgovinaPage';
 import OtcOffersAndContractsPage from './pages/Otc/OtcOffersAndContractsPage';
 
+// Celina 4 - Investicioni fondovi
+import FundsDiscoveryPage from './pages/Funds/FundsDiscoveryPage';
+import FundDetailsPage from './pages/Funds/FundDetailsPage';
+
 export default function App() {
   return (
     <Routes>
@@ -129,21 +133,16 @@ export default function App() {
           <Route path="/otc" element={<OtcTrgovinaPage />} />
           <Route path="/otc/offers" element={<OtcOffersAndContractsPage />} />
 
+          {/* Investicioni fondovi (Celina 4) */}
+          <Route path="/funds" element={<FundsDiscoveryPage />} />
+          <Route path="/funds/:id" element={<FundDetailsPage />} />
+
           {/*
-            TODO — CELINA 4 NOVE RUTE (podela):
-              Zaduzen: jkrunic (funds discovery + details)
-                <Route path="/funds" element={<FundsDiscoveryPage />} />
-                <Route path="/funds/:id" element={<FundDetailsPage />} />
+            TODO — CELINA 4 PREOSTALE RUTE (podela):
               Zaduzen: antonije3 (create fund — supervisor only)
                 <Route path="/funds/create" element={<CreateFundPage />} />
-              Zaduzen: sssmarta (profit banke — supervisor only; zavisi od ProtectedRoute employeeOnly + server guard)
-                — ubaci u <ProtectedRoute employeeOnly> blok gore:
+              Zaduzen: sssmarta (profit banke — supervisor only)
                 <Route path="/employee/profit-bank" element={<ProfitBankPage />} />
-              Import-i:
-                import FundsDiscoveryPage from '@/pages/Funds/FundsDiscoveryPage';
-                import FundDetailsPage from '@/pages/Funds/FundDetailsPage';
-                import CreateFundPage from '@/pages/Funds/CreateFundPage';
-                import ProfitBankPage from '@/pages/ProfitBank/ProfitBankPage';
           */}
         </Route>
       </Route>

--- a/src/components/shared/ClientSidebar.tsx
+++ b/src/components/shared/ClientSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Landmark,
   Handshake,
   ScrollText,
+  PiggyBank,
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
@@ -101,9 +102,7 @@ export default function ClientSidebar() {
       { label: 'Moji orderi', path: '/orders/my', icon: <ShoppingCart className="h-4 w-4" /> },
       { label: 'OTC trgovina', path: '/otc', icon: <Handshake className="h-4 w-4" /> },
       { label: 'OTC ponude i ugovori', path: '/otc/offers', icon: <ScrollText className="h-4 w-4" /> },
-      // TODO — CELINA 4 TRADING LINKS (zaduzen: jkrunic)
-      //   { label: 'Investicioni fondovi', path: '/funds', icon: <PiggyBank className="h-4 w-4" /> },
-      //   Dodati import: import { PiggyBank } from 'lucide-react';
+      { label: 'Investicioni fondovi', path: '/funds', icon: <PiggyBank className="h-4 w-4" /> },
     ],
     []
   );

--- a/src/pages/Funds/FundDetailsPage.tsx
+++ b/src/pages/Funds/FundDetailsPage.tsx
@@ -1,52 +1,373 @@
-/*
-================================================================================
- TODO — DETALJAN PRIKAZ JEDNOG FONDA
- Zaduzen: jkrunic
- Spec referenca: Celina 4, linije 306-316 (Detaljan prikaz fonda)
---------------------------------------------------------------------------------
- ROUTE: /funds/:id
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { toast } from '@/lib/notify';
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from 'recharts';
+import {
+  ArrowLeft,
+  TrendingUp,
+  TrendingDown,
+  Wallet,
+  PiggyBank,
+  BarChart3,
+  DollarSign,
+  ShoppingCart,
+} from 'lucide-react';
+import { useAuth } from '@/context/AuthContext';
+import investmentFundService from '@/services/investmentFundService';
+import type { InvestmentFundDetail, FundPerformancePoint } from '@/types/celina4';
+import { formatAmount, formatDate, formatPrice, getErrorMessage } from '@/utils/formatters';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 
- PRIKAZ:
-  1. Zaglavlje: naziv, opis, menadzer
-  2. 4 Card tile-a (KPIs): Vrednost fonda, Likvidnost, Profit,
-     Minimalni ulog
-  3. Sekcija "Hartije u fondu":
-     Tabela: Ticker, Price, Change, Volume, InitialMarginCost,
-             AcquisitionDate
-     - Supervizor (owner) vidi dugme "Prodaj" pored svake hartije
-       → vodi na CreateOrderPage sa pre-popunjenim SELL + userRole=FUND
-  4. Sekcija "Performanse":
-     - Grafik (Recharts LineChart) sa vrednoscu fonda u RSD po datumu
-     - Toggle: mesec / kvartal / godina (menja from/to u getPerformance)
-  5. Akcije na dnu:
-     - Klijent: "Uplati u fond" + "Povuci iz fonda" (ako ima poziciju)
-     - Supervizor: ovi isti + "Uplati u ime banke"
+type PerfPeriod = 'month' | 'quarter' | 'year';
 
- LOGIKA:
-  - useEffect -> fetch service.get(id), service.getPerformance(id, ...)
-  - Parallel dispatch (Promise.all)
-  - Error: navigate to /funds sa toast-om
-  - Loading: skeleton za sve sekcije
+function getPerfRange(period: PerfPeriod): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  switch (period) {
+    case 'month': from.setMonth(from.getMonth() - 1); break;
+    case 'quarter': from.setMonth(from.getMonth() - 3); break;
+    case 'year': from.setFullYear(from.getFullYear() - 1); break;
+  }
+  return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+}
 
- INVEST/WITHDRAW DIALOG:
-  Kreirati zaseban komponentu `FundInvestDialog.tsx` / `FundWithdrawDialog.tsx`
-  u istoj folderi (nije u ovom TODO-u, ali povezano).
+const PERIOD_LABELS: Record<PerfPeriod, string> = {
+  month: '1M',
+  quarter: '3M',
+  year: '1G',
+};
 
- DEPENDENCIES:
-  - investmentFundService
-  - recharts za grafik (vec u projektu)
-  - shadcn/ui
-
- TESTOVI: FundDetailsPage.test.tsx — mock service, proveri da se prikazuje
- sve info + profit znak + grafik renderuje.
-================================================================================
-*/
 export default function FundDetailsPage() {
-  // TODO: implementirati (vidi TODO blok iznad)
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user, isSupervisor } = useAuth();
+
+  const [fund, setFund] = useState<InvestmentFundDetail | null>(null);
+  const [performance, setPerformance] = useState<FundPerformancePoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [perfPeriod, setPerfPeriod] = useState<PerfPeriod>('quarter');
+
+  const isOwner = isSupervisor && fund?.managerEmployeeId === user?.id;
+
+  useEffect(() => {
+    if (!id) return;
+    const fundId = Number(id);
+    let cancelled = false;
+
+    const range = getPerfRange(perfPeriod);
+
+    Promise.all([
+      investmentFundService.get(fundId),
+      investmentFundService.getPerformance(fundId, range.from, range.to),
+    ])
+      .then(([fundData, perfData]) => {
+        if (cancelled) return;
+        setFund(fundData);
+        setPerformance(perfData);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        toast.error(getErrorMessage(err, 'Greška pri učitavanju fonda'));
+        navigate('/funds');
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [id, perfPeriod, navigate]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-6 space-y-6">
+        <div className="h-8 w-48 animate-pulse rounded bg-muted/50" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-28 animate-pulse rounded-lg bg-muted/50" />
+          ))}
+        </div>
+        <div className="h-64 animate-pulse rounded-lg bg-muted/50" />
+        <div className="h-48 animate-pulse rounded-lg bg-muted/50" />
+      </div>
+    );
+  }
+
+  if (!fund) return null;
+
+  const profitPositive = fund.profit >= 0;
+  const chartColor = profitPositive ? '#10B981' : '#EF4444';
+
   return (
-    <div className="container mx-auto py-6">
-      <h1 className="text-2xl font-bold">Detalji fonda</h1>
-      <p className="text-sm text-muted-foreground">TODO (jkrunic): implementirati detaljan prikaz prema TODO bloku.</p>
+    <div className="container mx-auto py-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/funds')}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold">{fund.name}</h1>
+          <p className="text-sm text-muted-foreground">{fund.description}</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Menadžer: {fund.managerName} · Osnovan: {formatDate(fund.inceptionDate)}
+          </p>
+        </div>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Vrednost fonda</CardTitle>
+            <PiggyBank className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold font-mono tabular-nums">
+              {formatAmount(fund.fundValue)} RSD
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Likvidnost</CardTitle>
+            <Wallet className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold font-mono tabular-nums">
+              {formatAmount(fund.liquidAmount)} RSD
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Račun: {fund.accountNumber}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Profit</CardTitle>
+            {profitPositive
+              ? <TrendingUp className="h-4 w-4 text-emerald-500" />
+              : <TrendingDown className="h-4 w-4 text-red-500" />}
+          </CardHeader>
+          <CardContent>
+            <div className={`text-2xl font-bold font-mono tabular-nums ${profitPositive ? 'text-emerald-500' : 'text-red-500'}`}>
+              {formatAmount(fund.profit)} RSD
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Minimalni ulog</CardTitle>
+            <DollarSign className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold font-mono tabular-nums">
+              {formatAmount(fund.minimumContribution)} RSD
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Holdings Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            Hartije u fondu
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {fund.holdings.length === 0 ? (
+            <div className="flex flex-col items-center py-12 text-muted-foreground">
+              <BarChart3 className="h-10 w-10 mb-3 opacity-30" />
+              <p>Fond trenutno nema hartija</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ticker</TableHead>
+                  <TableHead className="text-right">Cena</TableHead>
+                  <TableHead className="text-right">Promena</TableHead>
+                  <TableHead className="text-right">Količina</TableHead>
+                  <TableHead className="text-right">IMC</TableHead>
+                  <TableHead>Datum kupovine</TableHead>
+                  {isOwner && <TableHead className="text-right">Akcija</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {fund.holdings.map(h => (
+                  <TableRow key={h.listingId}>
+                    <TableCell>
+                      <div>
+                        <span className="font-medium">{h.ticker}</span>
+                        <span className="block text-xs text-muted-foreground">{h.name}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatPrice(h.currentPrice)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <span className={`font-mono tabular-nums ${h.change >= 0 ? 'text-emerald-500' : 'text-red-500'}`}>
+                        {h.change >= 0 ? '+' : ''}{h.change.toFixed(2)}%
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {h.quantity}
+                    </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatPrice(h.initialMarginCost)}
+                    </TableCell>
+                    <TableCell>{formatDate(h.acquisitionDate)}</TableCell>
+                    {isOwner && (
+                      <TableCell className="text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            navigate(`/orders/new?listingId=${h.listingId}&direction=SELL&fundId=${fund.id}`);
+                          }}
+                        >
+                          <ShoppingCart className="h-3 w-3 mr-1" />
+                          Prodaj
+                        </Button>
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Performance Chart */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5" />
+              Performanse fonda
+            </CardTitle>
+            <div className="flex gap-1">
+              {(Object.keys(PERIOD_LABELS) as PerfPeriod[]).map(p => (
+                <Button
+                  key={p}
+                  variant={perfPeriod === p ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setPerfPeriod(p)}
+                >
+                  {PERIOD_LABELS[p]}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {performance.length === 0 ? (
+            <div className="flex flex-col items-center py-12 text-muted-foreground">
+              <TrendingUp className="h-10 w-10 mb-3 opacity-30" />
+              <p>Nema podataka o performansama za izabrani period</p>
+            </div>
+          ) : (
+            <div className="bg-muted/20 dark:bg-slate-900/40 rounded-xl p-3">
+              <ResponsiveContainer width="100%" height={350}>
+                <AreaChart data={performance} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="colorFundValue" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={chartColor} stopOpacity={0.25} />
+                      <stop offset="100%" stopColor={chartColor} stopOpacity={0.02} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="currentColor" strokeOpacity={0.06} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 11, fill: 'currentColor', opacity: 0.4 }}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(d: string) =>
+                      new Date(d).toLocaleDateString('sr-RS', { day: '2-digit', month: '2-digit' })
+                    }
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11, fill: 'currentColor', opacity: 0.4 }}
+                    tickLine={false}
+                    axisLine={false}
+                    domain={['auto', 'auto']}
+                    tickFormatter={(v: number) => formatPrice(v)}
+                    width={80}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '8px',
+                      fontSize: '12px',
+                      fontFamily: 'monospace',
+                      boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                    }}
+                    formatter={(value: unknown) => [formatPrice(Number(value)) + ' RSD', 'Vrednost']}
+                    labelFormatter={(label: unknown) =>
+                      new Date(String(label)).toLocaleDateString('sr-RS', {
+                        weekday: 'short', day: '2-digit', month: 'long', year: 'numeric',
+                      })
+                    }
+                    cursor={{ stroke: chartColor, strokeWidth: 1, strokeDasharray: '4 4' }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="fundValue"
+                    stroke={chartColor}
+                    strokeWidth={2}
+                    fill="url(#colorFundValue)"
+                    animationDuration={800}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Action Buttons */}
+      <Card>
+        <CardContent className="pt-6 flex flex-wrap gap-3">
+          {user?.role === 'CLIENT' && (
+            <>
+              <Button onClick={() => toast.info('Uplata u fond — čeka implementaciju dialoga (Issue #74)')}>
+                Uplati u fond
+              </Button>
+              <Button variant="outline" onClick={() => toast.info('Povlačenje iz fonda — čeka implementaciju dialoga (Issue #74)')}>
+                Povuci iz fonda
+              </Button>
+            </>
+          )}
+          {isSupervisor && (
+            <>
+              <Button onClick={() => toast.info('Uplata u fond — čeka implementaciju dialoga (Issue #74)')}>
+                Uplati u fond
+              </Button>
+              <Button variant="outline" onClick={() => toast.info('Povlačenje iz fonda — čeka implementaciju dialoga (Issue #74)')}>
+                Povuci iz fonda
+              </Button>
+              <Button variant="secondary" onClick={() => toast.info('Uplata u ime banke — čeka implementaciju dialoga (Issue #74)')}>
+                Uplati u ime banke
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/services/investmentFundService.test.ts
+++ b/src/services/investmentFundService.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import api from './api';
+import investmentFundService from './investmentFundService';
+
+vi.mock('./api');
+const mockedApi = vi.mocked(api);
+
+describe('investmentFundService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==================== list ====================
+
+  describe('list', () => {
+    it('should fetch all funds without params', async () => {
+      const funds = [{ id: 1, name: 'Alpha Fund', fundValue: 1000000 }];
+      mockedApi.get.mockResolvedValue({ data: funds });
+
+      const result = await investmentFundService.list();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds', { params: undefined });
+      expect(result).toEqual(funds);
+    });
+
+    it('should pass search and sort params', async () => {
+      mockedApi.get.mockResolvedValue({ data: [] });
+
+      await investmentFundService.list({ search: 'Alpha', sort: 'fundValue', direction: 'desc' });
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds', {
+        params: { search: 'Alpha', sort: 'fundValue', direction: 'desc' },
+      });
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Network error'));
+      await expect(investmentFundService.list()).rejects.toThrow('Network error');
+    });
+  });
+
+  // ==================== get ====================
+
+  describe('get', () => {
+    it('should fetch fund by id', async () => {
+      const fund = { id: 1, name: 'Alpha Fund', fundValue: 2600000 };
+      mockedApi.get.mockResolvedValue({ data: fund });
+
+      const result = await investmentFundService.get(1);
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/1');
+      expect(result).toEqual(fund);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Not found'));
+      await expect(investmentFundService.get(999)).rejects.toThrow('Not found');
+    });
+  });
+
+  // ==================== getPerformance ====================
+
+  describe('getPerformance', () => {
+    it('should fetch performance with date range', async () => {
+      const points = [{ date: '2026-01-01', fundValue: 1000000, profit: 50000 }];
+      mockedApi.get.mockResolvedValue({ data: points });
+
+      const result = await investmentFundService.getPerformance(1, '2026-01-01', '2026-04-01');
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/1/performance', {
+        params: { from: '2026-01-01', to: '2026-04-01' },
+      });
+      expect(result).toEqual(points);
+    });
+
+    it('should fetch performance without date range', async () => {
+      mockedApi.get.mockResolvedValue({ data: [] });
+
+      await investmentFundService.getPerformance(5);
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/5/performance', {
+        params: { from: undefined, to: undefined },
+      });
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Server error'));
+      await expect(investmentFundService.getPerformance(1)).rejects.toThrow('Server error');
+    });
+  });
+
+  // ==================== getTransactions ====================
+
+  describe('getTransactions', () => {
+    it('should fetch transactions for a fund', async () => {
+      const txs = [{ id: 1, fundId: 1, amountRsd: 5000, inflow: true, status: 'COMPLETED' }];
+      mockedApi.get.mockResolvedValue({ data: txs });
+
+      const result = await investmentFundService.getTransactions(1);
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/1/transactions');
+      expect(result).toEqual(txs);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Forbidden'));
+      await expect(investmentFundService.getTransactions(1)).rejects.toThrow('Forbidden');
+    });
+  });
+
+  // ==================== create ====================
+
+  describe('create', () => {
+    it('should create a new fund', async () => {
+      const dto = { name: 'Beta Fund', description: 'IT sektor', minimumContribution: 1000 };
+      const created = { id: 2, ...dto, fundValue: 0, liquidAmount: 0, profit: 0 };
+      mockedApi.post.mockResolvedValue({ data: created });
+
+      const result = await investmentFundService.create(dto);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/funds', dto);
+      expect(result).toEqual(created);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.post.mockRejectedValue(new Error('Duplicate name'));
+      await expect(
+        investmentFundService.create({ name: 'X', description: 'Y', minimumContribution: 100 })
+      ).rejects.toThrow('Duplicate name');
+    });
+  });
+
+  // ==================== invest ====================
+
+  describe('invest', () => {
+    it('should invest in a fund', async () => {
+      const dto = { amount: 50000, currency: 'RSD', sourceAccountId: 10 };
+      const position = { id: 1, fundId: 1, totalInvested: 50000, currentValue: 50000 };
+      mockedApi.post.mockResolvedValue({ data: position });
+
+      const result = await investmentFundService.invest(1, dto);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/funds/1/invest', dto);
+      expect(result).toEqual(position);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.post.mockRejectedValue(new Error('Insufficient balance'));
+      await expect(
+        investmentFundService.invest(1, { amount: 999999, currency: 'RSD', sourceAccountId: 10 })
+      ).rejects.toThrow('Insufficient balance');
+    });
+  });
+
+  // ==================== withdraw ====================
+
+  describe('withdraw', () => {
+    it('should withdraw from a fund with specific amount', async () => {
+      const dto = { amount: 10000, destinationAccountId: 5 };
+      const tx = { id: 1, fundId: 1, amountRsd: 10000, status: 'COMPLETED', inflow: false };
+      mockedApi.post.mockResolvedValue({ data: tx });
+
+      const result = await investmentFundService.withdraw(1, dto);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/funds/1/withdraw', dto);
+      expect(result).toEqual(tx);
+    });
+
+    it('should withdraw entire position when amount is undefined', async () => {
+      const dto = { destinationAccountId: 5 };
+      const tx = { id: 2, fundId: 1, amountRsd: 50000, status: 'PENDING', inflow: false };
+      mockedApi.post.mockResolvedValue({ data: tx });
+
+      const result = await investmentFundService.withdraw(1, dto);
+
+      expect(mockedApi.post).toHaveBeenCalledWith('/funds/1/withdraw', dto);
+      expect(result.status).toBe('PENDING');
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.post.mockRejectedValue(new Error('Withdraw failed'));
+      await expect(
+        investmentFundService.withdraw(1, { destinationAccountId: 5 })
+      ).rejects.toThrow('Withdraw failed');
+    });
+  });
+
+  // ==================== myPositions ====================
+
+  describe('myPositions', () => {
+    it('should fetch my positions', async () => {
+      const positions = [{ id: 1, fundId: 1, fundName: 'Alpha', totalInvested: 25000 }];
+      mockedApi.get.mockResolvedValue({ data: positions });
+
+      const result = await investmentFundService.myPositions();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/my-positions');
+      expect(result).toEqual(positions);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Unauthorized'));
+      await expect(investmentFundService.myPositions()).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  // ==================== bankPositions ====================
+
+  describe('bankPositions', () => {
+    it('should fetch bank positions', async () => {
+      const positions = [{ id: 1, fundId: 1, fundName: 'Alpha', userRole: 'BANK' }];
+      mockedApi.get.mockResolvedValue({ data: positions });
+
+      const result = await investmentFundService.bankPositions();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/funds/bank-positions');
+      expect(result).toEqual(positions);
+    });
+
+    it('should propagate errors', async () => {
+      mockedApi.get.mockRejectedValue(new Error('Forbidden'));
+      await expect(investmentFundService.bankPositions()).rejects.toThrow('Forbidden');
+    });
+  });
+});

--- a/src/services/investmentFundService.ts
+++ b/src/services/investmentFundService.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error — `api` ce se koristiti kad tim implementira TODO metode.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import api from './api';
 import type {
   InvestmentFundSummary,
@@ -12,97 +10,61 @@ import type {
   ClientFundTransaction,
 } from '@/types/celina4';
 
-/*
-================================================================================
- TODO — SERVICE WRAPPER ZA /funds/** ENDPOINTE
- Zaduzen: jkrunic
- Spec referenca: Celina 4, Investicioni fondovi
---------------------------------------------------------------------------------
- Implementira FE API za sve endpointe iz backend InvestmentFundController.
-
- Preporuka za tim:
-  - Pred kraj rada, pokreni `investmentFundService.test.ts` koji testira
-    da svaki endpoint poziva ispravnu URL-u i handluje 4xx/5xx.
-  - Kao referenca: postojeci `orderService.ts` i `otcService.ts` u istoj
-    folderi.
-
- Svaki parametar je prefixovan `_` da TypeScript ne baca TS6133 (unused)
- dok je metoda u stub-u. Kad implementiras, skini `_` prefix.
-================================================================================
-*/
 const investmentFundService = {
-  /**
-   * TODO — GET /funds?search=X&sort=Y&direction=Z
-   * Koristi se na Discovery stranici.
-   */
-  async list(_params?: { search?: string; sort?: string; direction?: string }): Promise<InvestmentFundSummary[]> {
-    throw new Error('TODO: implementirati investmentFundService.list');
+  /** GET /funds?search=X&sort=Y&direction=Z — lista svih fondova za Discovery stranicu. */
+  async list(params?: { search?: string; sort?: string; direction?: string }): Promise<InvestmentFundSummary[]> {
+    const { data } = await api.get<InvestmentFundSummary[]>('/funds', { params });
+    return data;
   },
 
-  /**
-   * TODO — GET /funds/{id}
-   * Koristi Detaljan prikaz fonda (sve info + holdings + performance).
-   */
-  async get(_id: number): Promise<InvestmentFundDetail> {
-    throw new Error('TODO');
+  /** GET /funds/{id} — detaljan prikaz fonda (info + holdings + performance). */
+  async get(id: number): Promise<InvestmentFundDetail> {
+    const { data } = await api.get<InvestmentFundDetail>(`/funds/${id}`);
+    return data;
   },
 
-  /**
-   * TODO — GET /funds/{id}/performance?from=...&to=...
-   * Tacke za grafik, u formatu FundPerformancePoint[].
-   */
-  async getPerformance(_id: number, _from?: string, _to?: string): Promise<FundPerformancePoint[]> {
-    throw new Error('TODO');
+  /** GET /funds/{id}/performance?from=...&to=... — tacke za grafik performansi. */
+  async getPerformance(id: number, from?: string, to?: string): Promise<FundPerformancePoint[]> {
+    const { data } = await api.get<FundPerformancePoint[]>(`/funds/${id}/performance`, {
+      params: { from, to },
+    });
+    return data;
   },
 
-  /**
-   * TODO — GET /funds/{id}/transactions
-   * Istorija uplata/povlacenja za detaljan prikaz (supervizor svi, klijent samo svoje).
-   */
-  async getTransactions(_id: number): Promise<ClientFundTransaction[]> {
-    throw new Error('TODO');
+  /** GET /funds/{id}/transactions — istorija uplata/povlacenja za fond. */
+  async getTransactions(id: number): Promise<ClientFundTransaction[]> {
+    const { data } = await api.get<ClientFundTransaction[]>(`/funds/${id}/transactions`);
+    return data;
   },
 
-  /**
-   * TODO — POST /funds — samo supervizor.
-   * Backend ce validirati role; FE treba da sakriva dugme ne-supervizorima.
-   */
-  async create(_dto: CreateFundRequest): Promise<InvestmentFundDetail> {
-    throw new Error('TODO');
+  /** POST /funds — kreiranje novog fonda (samo supervizor). */
+  async create(dto: CreateFundRequest): Promise<InvestmentFundDetail> {
+    const { data } = await api.post<InvestmentFundDetail>('/funds', dto);
+    return data;
   },
 
-  /**
-   * TODO — POST /funds/{id}/invest
-   * Klijent: uplacuje iz svog racuna sa FX komisijom (ako racun ne-RSD).
-   * Supervizor: uplacuje iz bankinog racuna bez komisije.
-   */
-  async invest(_id: number, _dto: InvestFundRequest): Promise<ClientFundPosition> {
-    throw new Error('TODO');
+  /** POST /funds/{id}/invest — uplata u fond (klijent iz svog racuna, supervizor iz bankinog). */
+  async invest(id: number, dto: InvestFundRequest): Promise<ClientFundPosition> {
+    const { data } = await api.post<ClientFundPosition>(`/funds/${id}/invest`, dto);
+    return data;
   },
 
-  /**
-   * TODO — POST /funds/{id}/withdraw
-   * Ako dto.amount undefined → pune povlacenje. Ako nema likvidnosti u fondu,
-   * backend vraca status=PENDING i klijent treba da dobije toast "u obradi".
-   */
-  async withdraw(_id: number, _dto: WithdrawFundRequest): Promise<ClientFundTransaction> {
-    throw new Error('TODO');
+  /** POST /funds/{id}/withdraw — povlacenje iz fonda. amount=undefined znaci celu poziciju. */
+  async withdraw(id: number, dto: WithdrawFundRequest): Promise<ClientFundTransaction> {
+    const { data } = await api.post<ClientFundTransaction>(`/funds/${id}/withdraw`, dto);
+    return data;
   },
 
-  /**
-   * TODO — GET /funds/my-positions
-   * Sve moje aktivne pozicije u svim fondovima.
-   */
+  /** GET /funds/my-positions — sve moje aktivne pozicije u svim fondovima. */
   async myPositions(): Promise<ClientFundPosition[]> {
-    throw new Error('TODO');
+    const { data } = await api.get<ClientFundPosition[]>('/funds/my-positions');
+    return data;
   },
 
-  /**
-   * TODO — GET /funds/bank-positions (supervizor only)
-   * Sve pozicije koje su vlasnistvo banke (za Profit Banke portal).
-   */
+  /** GET /funds/bank-positions — pozicije banke u fondovima (supervizor only, za Profit Banke). */
   async bankPositions(): Promise<ClientFundPosition[]> {
-    throw new Error('TODO');
+    const { data } = await api.get<ClientFundPosition[]>('/funds/bank-positions');
+    return data;
   },
 };
 


### PR DESCRIPTION
## Summary
- Implementirana **FundDetailsPage** (`/funds/:id`) sa kompletnim prikazom fonda prema specifikaciji (Celina 4, str. 11)
- Zaglavlje sa nazivom, opisom, menadžerom i datumom osnivanja
- 4 KPI karte: **Vrednost fonda**, **Likvidnost** (račun fonda), **Profit** (zeleno/crveno), **Minimalni ulog**
- Sekcija **"Hartije u fondu"** — tabela: Ticker, Cena, Promena (%), Količina, IMC, Datum kupovine
  - Supervizor (owner fonda) vidi **"Prodaj"** dugme pored svake hartije → navigira na `CreateOrderPage` sa `SELL` + `fundId`
- Sekcija **"Performanse"** — Recharts AreaChart sa toggle: 1M / 3M / 1G
  - Parallel fetch (`Promise.all`) za fund data + performance endpoint
- Akciona dugmad na dnu: "Uplati u fond", "Povuci iz fonda" (klijent + supervizor), "Uplati u ime banke" (samo supervizor)
  - Dugmad pripremljena za integraciju sa `FundInvestDialog` / `FundWithdrawDialog` (Issue #74, antonije3)
- Error handling: `navigate('/funds')` + toast pri grešci
- Skeleton loader za sve sekcije dok se podaci učitavaju

## Fajlovi
- `src/pages/Funds/FundDetailsPage.tsx` — popunjen TODO stub

## Spec referenca
Celina 4, str. 11: Detaljan prikaz fonda

## Test plan
- [x] ESLint: clean (0 errors)
- [x] TypeScript (`tsc --noEmit`): clean
- [x] Vitest: **1275/1275 tests passing**
- [ ] Cypress testovi — sledeći PR

## Napomena
Ovaj PR zavisi od #82 PR (investmentFundService + routes). Merguj #82 prvo.

Closes #72