### PR TITLE
Implement OTC inter-bank contracts tab and SAGA exercise flow

### DIFF
--- a/cypress/e2e/celina4-live.cy.ts
+++ b/cypress/e2e/celina4-live.cy.ts
@@ -301,15 +301,16 @@ describe('Live C4: OTC Inter-bank Discovery', () => {
 
 // ============================================================
 //  FEATURE 8+9: OTC Inter-bank Offers + Contracts (Issue #68, #69 / ekalajdzic13322)
-//  Napomena: SAGA flow zahteva seed ponudu — BE tim treba da pripremi
+//  Live blokiran dok BE ne implementira /interbank/otc/offers* i /contracts*
+//  (trenutno controller vraca UnsupportedOperationException("TODO") → 400)
 // ============================================================
 describe('Live C4: OTC Inter-bank Offers + Contracts', () => {
   it.skip('TODO L28: Aktivne inter-bank ponude - bojenje odstupanja', () => {});
   it.skip('TODO L29: Kontraponuda - PATCH counter + refresh', () => {});
   it.skip('TODO L30: Prihvat ponude kreira inter-bank contract', () => {});
-  it.skip('TODO L31: Sklopljeni ugovor - "Iskoristi" dugme', () => {});
-  it.skip('TODO L32: SAGA exercise - progres modal prolazi sve 5 faza', () => {});
-  it.skip('TODO L33: ABORTED - failureReason se prikazuje', () => {});
+  it.skip('L31: Sklopljeni ugovor - "Iskoristi" dugme', () => {});
+  it.skip('L32: SAGA exercise - progres modal prolazi sve 5 faza', () => {});
+  it.skip('L33: ABORTED - failureReason se prikazuje', () => {});
 });
 
 

--- a/cypress/e2e/celina4-mock.cy.ts
+++ b/cypress/e2e/celina4-mock.cy.ts
@@ -98,8 +98,106 @@ const mockPerformance = [
   { date: '2026-01-01', fundValue: 2600000, profit: 150000 },
 ];
 
-// TODO(ekalajdzic13322) — mockOtcRemoteListings + mockOtcRemoteOffers za Issue #66-69
-// Referenca: src/types/celina4.ts → OtcInterbankListing, OtcInterbankOffer
+const mockOtcRemoteContracts = [
+  {
+    id: 'remote-contract-active',
+    listingId: 101,
+    listingTicker: 'AAPL',
+    listingName: 'Apple Inc.',
+    listingCurrency: 'USD',
+    buyerUserId: 'stefan.jovanovic',
+    buyerBankCode: 'BANKA1',
+    buyerName: 'Stefan Jovanovic',
+    sellerUserId: 'remote-seller-1',
+    sellerBankCode: 'BANKA2',
+    sellerName: 'Remote Seller',
+    quantity: 8,
+    strikePrice: 100,
+    premium: 25,
+    currentPrice: 126,
+    settlementDate: '2026-05-10',
+    status: 'ACTIVE',
+    createdAt: '2026-04-20T10:00:00Z',
+  },
+  {
+    id: 'remote-contract-exercised',
+    listingId: 102,
+    listingTicker: 'TSLA',
+    listingName: 'Tesla Inc.',
+    listingCurrency: 'USD',
+    buyerUserId: 'stefan.jovanovic',
+    buyerBankCode: 'BANKA1',
+    buyerName: 'Stefan Jovanovic',
+    sellerUserId: 'remote-seller-2',
+    sellerBankCode: 'BANKA3',
+    sellerName: 'Partner Seller',
+    quantity: 4,
+    strikePrice: 180,
+    premium: 18,
+    currentPrice: 195,
+    settlementDate: '2026-05-03',
+    status: 'EXERCISED',
+    createdAt: '2026-04-18T10:00:00Z',
+    exercisedAt: '2026-04-24T12:00:00Z',
+  },
+  {
+    id: 'remote-contract-expired',
+    listingId: 103,
+    listingTicker: 'NVDA',
+    listingName: 'NVIDIA Corp.',
+    listingCurrency: 'USD',
+    buyerUserId: 'stefan.jovanovic',
+    buyerBankCode: 'BANKA1',
+    buyerName: 'Stefan Jovanovic',
+    sellerUserId: 'remote-seller-3',
+    sellerBankCode: 'BANKA4',
+    sellerName: 'Remote Supervisor',
+    quantity: 2,
+    strikePrice: 90,
+    premium: 9,
+    currentPrice: 88,
+    settlementDate: '2026-04-10',
+    status: 'EXPIRED',
+    createdAt: '2026-04-01T10:00:00Z',
+  },
+];
+
+const mockOtcAccounts = [
+  {
+    id: 1,
+    accountNumber: '222000000000000001',
+    ownerName: 'Stefan Jovanovic',
+    accountType: 'CHECKING',
+    currency: 'USD',
+    balance: 5000,
+    availableBalance: 5000,
+    reservedBalance: 0,
+    dailyLimit: 100000,
+    monthlyLimit: 500000,
+    dailySpending: 0,
+    monthlySpending: 0,
+    maintenanceFee: 0,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    accountNumber: '222000000000000002',
+    ownerName: 'Stefan Jovanovic',
+    accountType: 'CHECKING',
+    currency: 'USD',
+    balance: 9000,
+    availableBalance: 9000,
+    reservedBalance: 0,
+    dailyLimit: 100000,
+    monthlyLimit: 500000,
+    dailySpending: 0,
+    monthlySpending: 0,
+    maintenanceFee: 0,
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+];
 
 // TODO(antonije3) — mockFundPositions + mockInterbankPayments za Issue #74/#76
 // Referenca: ClientFundPosition, InterbankPayment
@@ -386,11 +484,265 @@ describe('Mock C4: OTC Inter-bank Offers', () => {
 //  FEATURE 9: OTC Inter-bank Contracts + SAGA (Issue #69 / ekalajdzic13322)
 // ============================================================
 describe('Mock C4: OTC Inter-bank Contracts', () => {
-  it.skip('TODO S46: Tab prikazuje inter-bank ugovore sa filtr po statusu', () => {});
-  it.skip('TODO S47: "Iskoristi" dugme otvara dialog sa potvrdom + progres', () => {});
-  it.skip('TODO S48: SAGA progres modal prikazuje 5 faza', () => {});
-  it.skip('TODO S49: Polling status dok ne COMMITTED ili ABORTED', () => {});
-  it.skip('TODO S50: ABORTED status prikazuje failureReason', () => {});
+  beforeEach(() => {
+    cy.intercept('GET', '/api/otc/offers/active', { statusCode: 200, body: [] }).as('localOtcOffers');
+    cy.intercept('GET', '/api/otc/contracts*', { statusCode: 200, body: [] }).as('localOtcContracts');
+    cy.intercept('GET', '/api/accounts/my', { statusCode: 200, body: mockOtcAccounts }).as('myAccounts');
+    cy.intercept('GET', '/api/interbank/otc/contracts/my*', (req) => {
+      const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+      const body = !status || status === 'ALL'
+        ? mockOtcRemoteContracts
+        : mockOtcRemoteContracts.filter((contract) => contract.status === status);
+      req.reply({ statusCode: 200, body });
+    }).as('remoteContracts');
+  });
+
+  const openRemoteContractsTab = () => {
+    cy.clock(new Date('2026-04-25T09:00:00Z').getTime());
+    cy.visit('/otc/offers', { onBeforeLoad: setupClientSession });
+    cy.wait('@localOtcOffers');
+    cy.wait('@localOtcContracts');
+    cy.wait('@myAccounts');
+    cy.contains('button', 'Sklopljeni ugovori (inter-bank)').click();
+    cy.wait('@remoteContracts');
+    cy.wait('@myAccounts');
+  };
+
+  it('S46: Tab prikazuje inter-bank ugovore sa filtr po statusu', () => {
+    openRemoteContractsTab();
+
+    cy.contains('AAPL').should('be.visible');
+    cy.contains('TSLA').should('be.visible');
+    cy.contains('NVDA').should('be.visible');
+
+    cy.contains('[role="tab"]', 'Iskoriscen').click();
+    cy.wait('@remoteContracts').its('request.query.status').should('eq', 'EXERCISED');
+    cy.contains('TSLA').should('be.visible');
+    cy.contains('AAPL').should('not.exist');
+
+    cy.contains('[role="tab"]', 'Svi').click();
+    cy.wait('@remoteContracts');
+    cy.contains('AAPL').should('be.visible');
+  });
+
+  it('S47: "Iskoristi" dugme otvara dialog sa potvrdom + progres', () => {
+    cy.intercept('POST', '/api/interbank/otc/contracts/*/exercise*', {
+      statusCode: 200,
+      body: {
+        id: 501,
+        transactionId: 'otc-saga-fallback',
+        type: 'OTC',
+        status: 'INITIATED',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T10:00:00Z',
+        retryCount: 0,
+      },
+    }).as('exerciseContract');
+
+    openRemoteContractsTab();
+
+    cy.contains('tr', 'AAPL').within(() => {
+      cy.contains('button', 'Iskoristi').click();
+    });
+
+    cy.contains('Iskoristi inter-bank opciju').should('be.visible');
+    cy.contains('Strike × kolicina').should('be.visible');
+    cy.get('#interbank-exercise-account').select('2');
+    cy.contains('button', 'Potvrdi exercise').click();
+
+    cy.wait('@exerciseContract').then((interception) => {
+      expect(interception.request.query.buyerAccountId).to.equal('2');
+    });
+    cy.contains('SAGA exercise u toku').should('be.visible');
+    cy.contains('Izvrsavanje u toku').should('be.visible');
+  });
+
+  it('S48: SAGA progres modal prikazuje 5 faza', () => {
+    cy.intercept('POST', '/api/interbank/otc/contracts/*/exercise*', {
+      statusCode: 200,
+      body: {
+        id: 502,
+        transactionId: 'otc-saga-phases',
+        type: 'OTC',
+        status: 'INITIATED',
+        currentPhase: 'RESERVE_FUNDS',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T10:00:00Z',
+        retryCount: 0,
+      },
+    }).as('exerciseWithPhases');
+
+    openRemoteContractsTab();
+
+    cy.contains('tr', 'AAPL').within(() => {
+      cy.contains('button', 'Iskoristi').click();
+    });
+    cy.contains('button', 'Potvrdi exercise').click();
+
+    cy.wait('@exerciseWithPhases');
+    cy.contains('Rezervacija sredstava').should('be.visible');
+    cy.contains('Rezervacija hartija').should('be.visible');
+    cy.contains('Transfer').should('be.visible');
+    cy.contains('Prenos vlasnistva').should('be.visible');
+    cy.contains('Finalizacija').should('be.visible');
+  });
+
+  it('S49: Polling status dok ne COMMITTED ili ABORTED', () => {
+    let callCount = 0;
+
+    cy.intercept('POST', '/api/interbank/otc/contracts/*/exercise*', {
+      statusCode: 200,
+      body: {
+        id: 503,
+        transactionId: 'otc-saga-commit',
+        type: 'OTC',
+        status: 'INITIATED',
+        currentPhase: 'RESERVE_FUNDS',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T10:00:00Z',
+        retryCount: 0,
+      },
+    }).as('exerciseWithPolling');
+    cy.intercept('GET', '/api/interbank/payments/otc-saga-commit', (req) => {
+      callCount += 1;
+
+      if (callCount === 1) {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 503,
+            transactionId: 'otc-saga-commit',
+            type: 'OTC',
+            status: 'PREPARING',
+            currentPhase: 'RESERVE_SECURITIES',
+            senderBankCode: 'BANKA1',
+            receiverBankCode: 'BANKA2',
+            amount: 800,
+            currency: 'USD',
+            createdAt: '2026-04-25T10:00:00Z',
+            retryCount: 0,
+          },
+        });
+        return;
+      }
+
+      if (callCount === 2) {
+        req.reply({
+          statusCode: 200,
+          body: {
+            id: 503,
+            transactionId: 'otc-saga-commit',
+            type: 'OTC',
+            status: 'COMMITTING',
+            currentPhase: 'OWNERSHIP_TRANSFER',
+            senderBankCode: 'BANKA1',
+            receiverBankCode: 'BANKA2',
+            amount: 800,
+            currency: 'USD',
+            createdAt: '2026-04-25T10:00:00Z',
+            retryCount: 0,
+          },
+        });
+        return;
+      }
+
+      req.reply({
+        statusCode: 200,
+        body: {
+          id: 503,
+          transactionId: 'otc-saga-commit',
+          type: 'OTC',
+          status: 'COMMITTED',
+          currentPhase: 'FINALIZING',
+          senderBankCode: 'BANKA1',
+          receiverBankCode: 'BANKA2',
+          amount: 800,
+          currency: 'USD',
+          createdAt: '2026-04-25T10:00:00Z',
+          committedAt: '2026-04-25T10:00:09Z',
+          retryCount: 0,
+        },
+      });
+    }).as('sagaStatus');
+
+    openRemoteContractsTab();
+
+    cy.contains('tr', 'AAPL').within(() => {
+      cy.contains('button', 'Iskoristi').click();
+    });
+    cy.get('#interbank-exercise-account').select('1');
+    cy.contains('button', 'Potvrdi exercise').click();
+
+    cy.wait('@exerciseWithPolling');
+    cy.tick(3000);
+    cy.wait('@sagaStatus');
+    cy.tick(3000);
+    cy.wait('@sagaStatus');
+    cy.tick(3000);
+    cy.wait('@sagaStatus');
+
+    cy.contains('COMMITTED').should('be.visible');
+    cy.contains('Inter-bank exercise je uspesno finalizovan.').should('be.visible');
+  });
+
+  it('S50: ABORTED status prikazuje failureReason', () => {
+    cy.intercept('POST', '/api/interbank/otc/contracts/*/exercise*', {
+      statusCode: 200,
+      body: {
+        id: 504,
+        transactionId: 'otc-saga-aborted',
+        type: 'OTC',
+        status: 'INITIATED',
+        currentPhase: 'TRANSFER',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T10:00:00Z',
+        retryCount: 0,
+      },
+    }).as('exerciseAborted');
+    cy.intercept('GET', '/api/interbank/payments/otc-saga-aborted', {
+      statusCode: 200,
+      body: {
+        id: 504,
+        transactionId: 'otc-saga-aborted',
+        type: 'OTC',
+        status: 'ABORTED',
+        currentPhase: 'TRANSFER',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T10:00:00Z',
+        abortedAt: '2026-04-25T10:00:03Z',
+        retryCount: 0,
+        failureReason: 'Partner banka odbila prenos hartija.',
+      },
+    }).as('abortedStatus');
+
+    openRemoteContractsTab();
+
+    cy.contains('tr', 'AAPL').within(() => {
+      cy.contains('button', 'Iskoristi').click();
+    });
+    cy.contains('button', 'Potvrdi exercise').click();
+
+    cy.wait('@exerciseAborted');
+    cy.tick(3000);
+    cy.wait('@abortedStatus');
+
+    cy.contains('Partner banka odbila prenos hartija.').should('be.visible');
+  });
 });
 
 

--- a/src/pages/Otc/OtcInterBankContractsTab.test.tsx
+++ b/src/pages/Otc/OtcInterBankContractsTab.test.tsx
@@ -1,0 +1,312 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OtcInterBankContractsTab from './OtcInterBankContractsTab';
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'stefan.jovanovic@gmail.com',
+      username: 'client-1',
+      firstName: 'Stefan',
+      lastName: 'Jovanovic',
+      permissions: [],
+    },
+    isAdmin: false,
+    isAgent: false,
+    isSupervisor: false,
+  }),
+}));
+
+vi.mock('@/services/interbankOtcService', () => ({
+  default: {
+    listMyContracts: vi.fn(),
+    exerciseContract: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/accountService', () => ({
+  accountService: {
+    getMyAccounts: vi.fn(),
+    getBankAccounts: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/notify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import interbankOtcService from '@/services/interbankOtcService';
+import { accountService } from '@/services/accountService';
+import api from '@/services/api';
+import { toast } from '@/lib/notify';
+
+const mockedInterbankOtcService = vi.mocked(interbankOtcService);
+const mockedAccountService = vi.mocked(accountService);
+const mockedApi = vi.mocked(api);
+const mockedToast = vi.mocked(toast);
+
+const activeBuyerContract = {
+  id: 'contract-1',
+  listingId: 11,
+  listingTicker: 'AAPL',
+  listingName: 'Apple Inc.',
+  listingCurrency: 'USD',
+  buyerUserId: 'client-1',
+  buyerBankCode: 'BANKA1',
+  buyerName: 'Stefan Jovanovic',
+  sellerUserId: 'remote-seller',
+  sellerBankCode: 'BANKA2',
+  sellerName: 'Remote Seller',
+  quantity: 8,
+  strikePrice: 100,
+  premium: 25,
+  currentPrice: 126,
+  settlementDate: '2099-05-10',
+  status: 'ACTIVE' as const,
+  createdAt: '2026-04-25T10:00:00Z',
+};
+
+const sellerSideContract = {
+  ...activeBuyerContract,
+  id: 'contract-2',
+  listingTicker: 'MSFT',
+  buyerUserId: 'partner-1',
+  buyerName: 'Partner Buyer',
+  sellerUserId: 'client-1',
+  sellerName: 'Stefan Jovanovic',
+};
+
+const expiredContract = {
+  ...activeBuyerContract,
+  id: 'contract-3',
+  listingTicker: 'NVDA',
+  settlementDate: '2020-01-10',
+  status: 'EXPIRED' as const,
+};
+
+const accounts = [
+  {
+    id: 1,
+    accountNumber: '222000000000000001',
+    currency: 'USD',
+    availableBalance: 5000,
+    balance: 5000,
+    status: 'ACTIVE',
+  },
+  {
+    id: 2,
+    accountNumber: '222000000000000002',
+    currency: 'USD',
+    availableBalance: 9000,
+    balance: 9000,
+    status: 'ACTIVE',
+  },
+];
+
+describe('OtcInterBankContractsTab', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useRealTimers();
+    mockedInterbankOtcService.listMyContracts.mockResolvedValue([
+      activeBuyerContract,
+      sellerSideContract,
+      expiredContract,
+    ]);
+    mockedAccountService.getMyAccounts.mockResolvedValue(accounts as never);
+    mockedApi.get.mockResolvedValue({ data: {} } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders contracts and shows exercise only for active buyer contracts before settlement', async () => {
+    render(<OtcInterBankContractsTab />);
+
+    expect(await screen.findByText('AAPL')).toBeInTheDocument();
+    expect(screen.getByText('MSFT')).toBeInTheDocument();
+    expect(screen.getByText('NVDA')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Iskoristi/i })).toHaveLength(1);
+    expect(screen.getAllByText('Aktivan').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Istekao').length).toBeGreaterThan(0);
+  });
+
+  it('refetches contracts with a status filter', async () => {
+    const user = userEvent.setup();
+    render(<OtcInterBankContractsTab />);
+
+    await screen.findByText('AAPL');
+    await user.click(screen.getByRole('tab', { name: 'Iskoriscen' }));
+
+    await waitFor(() => {
+      expect(mockedInterbankOtcService.listMyContracts).toHaveBeenLastCalledWith('EXERCISED');
+    });
+  });
+
+  it('opens the exercise dialog and falls back to a spinner when currentPhase is missing', async () => {
+    const user = userEvent.setup();
+    mockedInterbankOtcService.exerciseContract.mockResolvedValue({
+      id: 77,
+      transactionId: 'otc-tx-1',
+      type: 'OTC',
+      status: 'INITIATED',
+      senderBankCode: 'BANKA1',
+      receiverBankCode: 'BANKA2',
+      amount: 800,
+      currency: 'USD',
+      createdAt: '2026-04-25T12:00:00Z',
+      retryCount: 0,
+    });
+
+    render(<OtcInterBankContractsTab />);
+
+    const contractRow = (await screen.findByText('AAPL')).closest('tr');
+    expect(contractRow).not.toBeNull();
+    await user.click(within(contractRow as HTMLElement).getByRole('button', { name: /Iskoristi/i }));
+
+    expect(screen.getByRole('dialog', { name: /Iskoristi inter-bank opciju/i })).toBeInTheDocument();
+    expect(screen.getByText(/Strike × kolicina/i)).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText(/Racun za placanje strike cene/i), '2');
+    await user.click(screen.getByRole('button', { name: /Potvrdi exercise/i }));
+
+    await waitFor(() => {
+      expect(mockedInterbankOtcService.exerciseContract).toHaveBeenCalledWith('contract-1', 2);
+    });
+
+    expect(await screen.findByText(/Izvrsavanje u toku/i)).toBeInTheDocument();
+    expect(screen.getByText(/currentPhase/i)).toBeInTheDocument();
+  });
+
+  it('shows all saga phases and polls until the transaction is committed', async () => {
+    const user = userEvent.setup();
+
+    mockedInterbankOtcService.listMyContracts
+      .mockResolvedValueOnce([activeBuyerContract])
+      .mockResolvedValueOnce([{ ...activeBuyerContract, status: 'EXERCISED' }]);
+    mockedInterbankOtcService.exerciseContract.mockResolvedValue({
+      id: 88,
+      transactionId: 'otc-tx-committed',
+      type: 'OTC',
+      status: 'INITIATED',
+      currentPhase: 'RESERVE_FUNDS',
+      senderBankCode: 'BANKA1',
+      receiverBankCode: 'BANKA2',
+      amount: 800,
+      currency: 'USD',
+      createdAt: '2026-04-25T12:00:00Z',
+      retryCount: 0,
+    });
+    mockedApi.get.mockResolvedValueOnce({
+      data: {
+        id: 88,
+        transactionId: 'otc-tx-committed',
+        type: 'OTC',
+        status: 'COMMITTED',
+        currentPhase: 'FINALIZING',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T12:00:00Z',
+        committedAt: '2026-04-25T12:00:09Z',
+        retryCount: 0,
+      },
+    } as never);
+
+    render(<OtcInterBankContractsTab />);
+
+    const contractRow = (await screen.findByText('AAPL')).closest('tr');
+    await user.click(within(contractRow as HTMLElement).getByRole('button', { name: /Iskoristi/i }));
+    vi.useFakeTimers();
+    await act(async () => {
+      screen.getByRole('button', { name: /Potvrdi exercise/i }).click();
+    });
+
+    expect(screen.getByText('Rezervacija sredstava')).toBeInTheDocument();
+    expect(screen.getByText('Rezervacija hartija')).toBeInTheDocument();
+    expect(screen.getByText('Transfer')).toBeInTheDocument();
+    expect(screen.getByText('Prenos vlasnistva')).toBeInTheDocument();
+    expect(screen.getByText('Finalizacija')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(mockedApi.get).toHaveBeenCalledWith('/interbank/payments/otc-tx-committed');
+    });
+    await waitFor(() => {
+      expect(mockedToast.success).toHaveBeenCalledWith('Inter-bank exercise je uspesno finalizovan.');
+    });
+    await waitFor(() => {
+      expect(mockedInterbankOtcService.listMyContracts).toHaveBeenLastCalledWith(undefined);
+    });
+  });
+
+  it('shows failure reason when saga is aborted', async () => {
+    const user = userEvent.setup();
+
+    mockedInterbankOtcService.exerciseContract.mockResolvedValue({
+      id: 99,
+      transactionId: 'otc-tx-aborted',
+      type: 'OTC',
+      status: 'INITIATED',
+      currentPhase: 'TRANSFER',
+      senderBankCode: 'BANKA1',
+      receiverBankCode: 'BANKA2',
+      amount: 800,
+      currency: 'USD',
+      createdAt: '2026-04-25T12:00:00Z',
+      retryCount: 0,
+    });
+    mockedApi.get.mockResolvedValueOnce({
+      data: {
+        id: 99,
+        transactionId: 'otc-tx-aborted',
+        type: 'OTC',
+        status: 'ABORTED',
+        currentPhase: 'TRANSFER',
+        senderBankCode: 'BANKA1',
+        receiverBankCode: 'BANKA2',
+        amount: 800,
+        currency: 'USD',
+        createdAt: '2026-04-25T12:00:00Z',
+        abortedAt: '2026-04-25T12:00:09Z',
+        retryCount: 0,
+        failureReason: 'Partner banka odbila prenos hartija.',
+      },
+    } as never);
+
+    render(<OtcInterBankContractsTab />);
+
+    const contractRow = (await screen.findByText('AAPL')).closest('tr');
+    await user.click(within(contractRow as HTMLElement).getByRole('button', { name: /Iskoristi/i }));
+    vi.useFakeTimers();
+    await act(async () => {
+      screen.getByRole('button', { name: /Potvrdi exercise/i }).click();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    vi.useRealTimers();
+
+    expect(screen.getByText('Partner banka odbila prenos hartija.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockedToast.error).toHaveBeenCalledWith('Partner banka odbila prenos hartija.');
+    });
+  });
+});

--- a/src/pages/Otc/OtcInterBankContractsTab.tsx
+++ b/src/pages/Otc/OtcInterBankContractsTab.tsx
@@ -1,40 +1,720 @@
-/*
-================================================================================
- TODO — TAB "SKLOPLJENI INTER-BANK UGOVORI" (SAGA EXERCISE)
- Zaduzen: ekalajdzic13322
- Spec referenca: Celina 4, linije 473-519 (SAGA + Exercise)
---------------------------------------------------------------------------------
- Sadrzaj: lista sklopljenih inter-bank ugovora (po statusu: ACTIVE, EXERCISED, EXPIRED).
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Wallet,
+  X,
+  XCircle,
+  Zap,
+} from 'lucide-react';
+import { toast } from '@/lib/notify';
+import { useAuth } from '@/context/AuthContext';
+import api from '@/services/api';
+import interbankOtcService from '@/services/interbankOtcService';
+import { accountService } from '@/services/accountService';
+import type { Account } from '@/types/celina2';
+import type {
+  InterbankTransaction,
+  OtcInterbankContract,
+  OtcInterbankContractStatus,
+} from '@/types/celina4';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { asArray, formatAmount, formatDate, formatDateTime, getErrorMessage } from '@/utils/formatters';
 
- AKCIJA "ISKORISTI" (samo za ACTIVE koje sam kupac + settlementDate > today):
-   - Klikom se otvara Dialog sa pregledom (strike * qty = total cost,
-     trenutna cena, profit projekcija, izbor racuna za placanje).
-   - Potvrdom se poziva interbankOtcService.exerciseContract(contractId, accountId).
-   - Backend kreira InterbankTransaction sa type=OTC, krece kroz SAGA.
-   - FE treba da prikaze modal sa progresom:
-       "1. Rezervacija sredstava..." ✓
-       "2. Rezervacija hartija u drugoj banci..." ✓
-       "3. Transfer sredstava..." ✓
-       "4. Prenos vlasnistva..." ✓
-       "5. Finalizacija..." ✓
-     Implementacija: poll-uj GET /interbank/payments/{txId} (ili poseban
-     OTC status endpoint) dok status ne bude COMMITTED ili ABORTED.
+const CONTRACT_STATUS_LABEL: Record<OtcInterbankContractStatus, string> = {
+  ACTIVE: 'Aktivan',
+  EXERCISED: 'Iskoriscen',
+  EXPIRED: 'Istekao',
+};
 
- PROGRES FAZE:
-  BE treba da vrati "currentPhase" field u tx response (DODATI u
-  InterbankTransaction DTO kao derived field). Ako BE nije jos pripremio
-  to, fallback: prikazi samo "Izvrsavanje u toku..." spinner.
+const SAGA_PHASES = [
+  'Rezervacija sredstava',
+  'Rezervacija hartija',
+  'Transfer',
+  'Prenos vlasnistva',
+  'Finalizacija',
+] as const;
 
- INTEGRACIJA:
-  OtcOffersAndContractsPage ce renderovati ovaj tab kad se klikne
-  na "Sklopljeni (inter-bank)".
-================================================================================
-*/
+type FilterValue = OtcInterbankContractStatus | 'ALL';
+
+type SagaProgressState = {
+  contract: OtcInterbankContract;
+  transaction: InterbankTransaction;
+};
+
+const selectClassName =
+  'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background';
+
+function isTerminalStatus(status: InterbankTransaction['status']) {
+  return status === 'COMMITTED' || status === 'ABORTED' || status === 'STUCK';
+}
+
+function getStatusBadgeVariant(status: OtcInterbankContractStatus): 'success' | 'secondary' | 'warning' {
+  if (status === 'ACTIVE') return 'success';
+  if (status === 'EXERCISED') return 'secondary';
+  return 'warning';
+}
+
+function getTransactionLookupId(transaction: InterbankTransaction): string {
+  return transaction.transactionId || String(transaction.id);
+}
+
+function normalizePhase(phase: string | null | undefined): string {
+  return String(phase ?? '')
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_');
+}
+
+function getCurrentPhaseIndex(transaction: InterbankTransaction): number | null {
+  if (transaction.status === 'COMMITTED') return 5;
+
+  const phase = normalizePhase(transaction.currentPhase);
+  if (!phase) {
+    return null;
+  }
+
+  if (phase.includes('FINAL') || phase.includes('COMMIT')) return 5;
+  if (phase.includes('OWNERSHIP') || phase.includes('VLASNIST')) return 4;
+  if (phase.includes('TRANSFER')) return 3;
+  if (phase.includes('SECUR') || phase.includes('HARTIJ') || phase.includes('STOCK')) return 2;
+  if (phase.includes('FUND') || phase.includes('SREDST')) return 1;
+
+  return null;
+}
+
+function isFutureSettlementDate(settlementDate: string): boolean {
+  const date = new Date(`${settlementDate}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return false;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date.getTime() > today.getTime();
+}
+
+function matchesCurrentUser(contract: OtcInterbankContract, user: ReturnType<typeof useAuth>['user']): boolean {
+  if (!user) return false;
+
+  const identifiers = new Set(
+    [
+      String(user.id),
+      user.email,
+      user.username,
+      `${user.firstName} ${user.lastName}`.trim(),
+    ]
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  return [contract.buyerUserId, contract.buyerName]
+    .map((value) => value.trim().toLowerCase())
+    .some((value) => identifiers.has(value));
+}
+
+function getPreferredAccount(accounts: Account[], currency: string): Account | undefined {
+  return accounts.find((account) => account.currency === currency) ?? accounts[0];
+}
+
 export default function OtcInterBankContractsTab() {
-  // TODO: implementirati
+  const { user, isAdmin, isAgent, isSupervisor } = useAuth();
+  const isEmployee = isAdmin || isAgent || isSupervisor;
+
+  const [contracts, setContracts] = useState<OtcInterbankContract[]>([]);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [filter, setFilter] = useState<FilterValue>('ALL');
+  const [loadingContracts, setLoadingContracts] = useState(true);
+  const [selectedContract, setSelectedContract] = useState<OtcInterbankContract | null>(null);
+  const [selectedAccountId, setSelectedAccountId] = useState('');
+  const [busyContractId, setBusyContractId] = useState<string | null>(null);
+  const [progressState, setProgressState] = useState<SagaProgressState | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+
+  const reloadContracts = useCallback(async (nextFilter: FilterValue = filter) => {
+    setLoadingContracts(true);
+    try {
+      const data = await interbankOtcService.listMyContracts(nextFilter === 'ALL' ? undefined : nextFilter);
+      setContracts(data ?? []);
+    } catch {
+      toast.error('Neuspesno ucitavanje inter-bank ugovora.');
+      setContracts([]);
+    } finally {
+      setLoadingContracts(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    void reloadContracts(filter);
+  }, [filter, reloadContracts]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const data = isEmployee
+          ? asArray<Account>(await accountService.getBankAccounts())
+          : asArray<Account>(await accountService.getMyAccounts());
+        setAccounts(data.filter((account) => account.status === 'ACTIVE'));
+      } catch {
+        setAccounts([]);
+      }
+    })();
+  }, [isEmployee]);
+
+  useEffect(() => {
+    if (!progressState) {
+      return;
+    }
+
+    if (isTerminalStatus(progressState.transaction.status)) {
+      return;
+    }
+
+    const transactionLookupId = getTransactionLookupId(progressState.transaction);
+    const intervalId = window.setInterval(() => {
+      void (async () => {
+        try {
+          const { data } = await api.get<InterbankTransaction>(`/interbank/payments/${transactionLookupId}`);
+          setProgressState((current) => current ? { ...current, transaction: data } : current);
+
+          if (isTerminalStatus(data.status)) {
+            window.clearInterval(intervalId);
+            await reloadContracts(filter);
+
+            if (data.status === 'COMMITTED') {
+              toast.success('Inter-bank exercise je uspesno finalizovan.');
+            } else {
+              toast.error(data.failureReason || 'Inter-bank exercise je prekinut.');
+            }
+          }
+        } catch (error) {
+          window.clearInterval(intervalId);
+          const message = getErrorMessage(error, 'Neuspesno pracenje inter-bank SAGA statusa.');
+          setPollError(message);
+          toast.error(message);
+        }
+      })();
+    }, 3000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [filter, progressState, reloadContracts]);
+
+  const currentPhaseIndex = getCurrentPhaseIndex(progressState?.transaction ?? {
+    id: 0,
+    transactionId: '',
+    type: 'OTC',
+    status: 'INITIATED',
+    senderBankCode: '',
+    receiverBankCode: '',
+    createdAt: '',
+    retryCount: 0,
+  });
+
+  const progressValue = currentPhaseIndex == null ? 15 : (currentPhaseIndex / SAGA_PHASES.length) * 100;
+  const progressTerminal = progressState ? isTerminalStatus(progressState.transaction.status) : false;
+
+  const openExerciseDialog = (contract: OtcInterbankContract) => {
+    const preferredAccount = getPreferredAccount(accounts, contract.listingCurrency);
+    setSelectedContract(contract);
+    setSelectedAccountId(preferredAccount ? String(preferredAccount.id) : '');
+  };
+
+  const closeExerciseDialog = () => {
+    if (busyContractId) {
+      return;
+    }
+    setSelectedContract(null);
+    setSelectedAccountId('');
+  };
+
+  const closeProgressDialog = () => {
+    if (!progressTerminal && !pollError) {
+      return;
+    }
+    setProgressState(null);
+    setPollError(null);
+  };
+
+  const handleExercise = async () => {
+    if (!selectedContract) {
+      return;
+    }
+
+    const buyerAccountId = Number(selectedAccountId);
+    if (!Number.isFinite(buyerAccountId) || buyerAccountId <= 0) {
+      toast.error('Izaberite racun za placanje strike cene.');
+      return;
+    }
+
+    setBusyContractId(selectedContract.id);
+    try {
+      const transaction = await interbankOtcService.exerciseContract(selectedContract.id, buyerAccountId);
+      setSelectedContract(null);
+      setPollError(null);
+      setProgressState({ contract: selectedContract, transaction });
+
+      if (isTerminalStatus(transaction.status)) {
+        await reloadContracts(filter);
+
+        if (transaction.status === 'COMMITTED') {
+          toast.success('Inter-bank exercise je uspesno finalizovan.');
+        } else {
+          toast.error(transaction.failureReason || 'Inter-bank exercise je prekinut.');
+        }
+      }
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Pokretanje inter-bank exercise flow-a nije uspelo.'));
+    } finally {
+      setBusyContractId(null);
+    }
+  };
+
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => String(account.id) === selectedAccountId) ?? null,
+    [accounts, selectedAccountId],
+  );
+
+  const selectedContractMetrics = useMemo(() => {
+    if (!selectedContract) {
+      return null;
+    }
+
+    const strikeCost = selectedContract.strikePrice * selectedContract.quantity;
+    const marketValue =
+      selectedContract.currentPrice != null
+        ? selectedContract.currentPrice * selectedContract.quantity
+        : null;
+    const projectedProfit =
+      marketValue != null
+        ? marketValue - strikeCost - selectedContract.premium
+        : null;
+
+    return { strikeCost, marketValue, projectedProfit };
+  }, [selectedContract]);
+
   return (
-    <div>
-      <p className="text-sm text-muted-foreground">TODO (ekalajdzic13322): implementirati inter-bank ugovore sa SAGA exercise flow-om.</p>
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle>Sklopljeni inter-bank ugovori</CardTitle>
+          <div className="flex gap-1" role="tablist" aria-label="Filter statusa inter-bank ugovora">
+            {(['ALL', 'ACTIVE', 'EXERCISED', 'EXPIRED'] as FilterValue[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setFilter(value)}
+                className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                  filter === value
+                    ? 'bg-indigo-500 text-white'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+                role="tab"
+                aria-selected={filter === value}
+              >
+                {value === 'ALL' ? 'Svi' : CONTRACT_STATUS_LABEL[value]}
+              </button>
+            ))}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loadingContracts ? (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="h-14 animate-pulse rounded bg-muted/50" />
+              ))}
+            </div>
+          ) : contracts.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Nema inter-bank ugovora za izabrani status.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Hartija</TableHead>
+                  <TableHead>Banka kupca / prodavca</TableHead>
+                  <TableHead>Kupac / Prodavac</TableHead>
+                  <TableHead>Kolicina</TableHead>
+                  <TableHead>Strike / Premija</TableHead>
+                  <TableHead>Trenutna cena</TableHead>
+                  <TableHead>Dospece</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Akcija</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {contracts.map((contract) => {
+                  const amBuyer = matchesCurrentUser(contract, user);
+                  const canExercise =
+                    contract.status === 'ACTIVE' &&
+                    amBuyer &&
+                    isFutureSettlementDate(contract.settlementDate);
+
+                  return (
+                    <TableRow key={contract.id}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-semibold">{contract.listingTicker}</span>
+                          <span className="text-xs text-muted-foreground">{contract.listingName}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        <div>Kupac: {contract.buyerBankCode}</div>
+                        <div className="text-muted-foreground">Prodavac: {contract.sellerBankCode}</div>
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        <div>Kupac: {contract.buyerName}</div>
+                        <div className="text-muted-foreground">Prodavac: {contract.sellerName}</div>
+                      </TableCell>
+                      <TableCell className="font-mono">{contract.quantity}</TableCell>
+                      <TableCell className="font-mono text-sm">
+                        <div>
+                          {formatAmount(contract.strikePrice)} {contract.listingCurrency}
+                        </div>
+                        <div className="text-muted-foreground">
+                          Prem: {formatAmount(contract.premium)} {contract.listingCurrency}
+                        </div>
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {contract.currentPrice != null
+                          ? `${formatAmount(contract.currentPrice)} ${contract.listingCurrency}`
+                          : '-'}
+                      </TableCell>
+                      <TableCell>{formatDate(contract.settlementDate)}</TableCell>
+                      <TableCell>
+                        <Badge variant={getStatusBadgeVariant(contract.status)}>
+                          {CONTRACT_STATUS_LABEL[contract.status]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {canExercise ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={busyContractId === contract.id}
+                            onClick={() => openExerciseDialog(contract)}
+                            className="bg-gradient-to-r from-indigo-500 to-violet-600 text-white"
+                          >
+                            <Zap className="mr-1 h-3.5 w-3.5" />
+                            Iskoristi
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {accounts.length === 0 && (
+        <Alert variant="warning">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Nemate aktivan racun za placanje strike cene.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Dialog.Root open={!!selectedContract} onOpenChange={(open) => !open && closeExerciseDialog()}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-background shadow-2xl">
+            <div className="flex items-start justify-between border-b p-6">
+              <div>
+                <Dialog.Title className="text-xl font-semibold">
+                  Iskoristi inter-bank opciju
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+                  Pregled troska, projekcije profita i izbor racuna za placanje strike cene.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  disabled={busyContractId != null}
+                  className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  aria-label="Zatvori"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </Dialog.Close>
+            </div>
+
+            {selectedContract && selectedContractMetrics && (
+              <div className="space-y-5 p-6">
+                <div className="grid gap-3 md:grid-cols-3">
+                  <Card>
+                    <CardContent className="p-4">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        Strike × kolicina
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {formatAmount(selectedContractMetrics.strikeCost)} {selectedContract.listingCurrency}
+                      </div>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardContent className="p-4">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        Trenutna trzisna vrednost
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">
+                        {selectedContractMetrics.marketValue != null
+                          ? `${formatAmount(selectedContractMetrics.marketValue)} ${selectedContract.listingCurrency}`
+                          : '-'}
+                      </div>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardContent className="p-4">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                        Profit projekcija
+                      </div>
+                      <div
+                        className={`mt-2 text-lg font-semibold ${
+                          (selectedContractMetrics.projectedProfit ?? 0) >= 0
+                            ? 'text-emerald-600'
+                            : 'text-red-600'
+                        }`}
+                      >
+                        {selectedContractMetrics.projectedProfit != null
+                          ? `${formatAmount(selectedContractMetrics.projectedProfit)} ${selectedContract.listingCurrency}`
+                          : '-'}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </div>
+
+                <div className="rounded-lg border bg-muted/20 p-4 text-sm">
+                  <div className="font-medium">
+                    {selectedContract.listingTicker} · {selectedContract.quantity} akcija
+                  </div>
+                  <div className="mt-1 text-muted-foreground">
+                    Dospece: {formatDate(selectedContract.settlementDate)} · Kreiran: {formatDateTime(selectedContract.createdAt)}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="interbank-exercise-account">
+                    Racun za placanje strike cene
+                  </Label>
+                  <select
+                    id="interbank-exercise-account"
+                    className={selectClassName}
+                    value={selectedAccountId}
+                    onChange={(event) => setSelectedAccountId(event.target.value)}
+                  >
+                    <option value="">Izaberite racun</option>
+                    {accounts.map((account) => (
+                      <option key={account.id} value={String(account.id)}>
+                        {account.accountNumber} · {account.currency}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedAccount && (
+                    <div className="rounded-lg border bg-muted/20 p-3 text-xs text-muted-foreground">
+                      Dostupno: {formatAmount(selectedAccount.availableBalance)} {selectedAccount.currency}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex justify-end gap-2">
+                  <Button type="button" variant="ghost" onClick={closeExerciseDialog}>
+                    Otkazi
+                  </Button>
+                  <Button
+                    type="button"
+                    disabled={busyContractId === selectedContract.id}
+                    onClick={handleExercise}
+                    className="bg-gradient-to-r from-indigo-500 to-violet-600 text-white"
+                  >
+                    {busyContractId === selectedContract.id ? (
+                      <>
+                        <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                        Pokrecem SAGA...
+                      </>
+                    ) : (
+                      <>
+                        <Wallet className="mr-1 h-4 w-4" />
+                        Potvrdi exercise
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root
+        open={!!progressState}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeProgressDialog();
+          }
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-background shadow-2xl">
+            <div className="flex items-start justify-between border-b p-6">
+              <div>
+                <Dialog.Title className="text-xl font-semibold">
+                  SAGA exercise u toku
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+                  Status inter-bank prenosa novca i vlasnistva nad hartijama.
+                </Dialog.Description>
+              </div>
+              {progressTerminal || pollError ? (
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    aria-label="Zatvori"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </Dialog.Close>
+              ) : null}
+            </div>
+
+            {progressState && (
+              <div className="space-y-5 p-6">
+                <div className="rounded-lg border bg-muted/20 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium">
+                        {progressState.contract.listingTicker} · {progressState.contract.quantity} akcija
+                      </div>
+                      <div className="mt-1 text-sm text-muted-foreground">
+                        Transaction ID: {getTransactionLookupId(progressState.transaction)}
+                      </div>
+                    </div>
+                    <Badge
+                      variant={
+                        progressState.transaction.status === 'COMMITTED'
+                          ? 'success'
+                          : progressState.transaction.status === 'ABORTED'
+                            ? 'destructive'
+                            : 'info'
+                      }
+                    >
+                      {progressState.transaction.status}
+                    </Badge>
+                  </div>
+                </div>
+
+                {currentPhaseIndex == null ? (
+                  <Alert variant={progressTerminal ? 'success' : pollError ? 'destructive' : 'info'}>
+                    {pollError ? (
+                      <XCircle className="h-4 w-4" />
+                    ) : progressTerminal ? (
+                      <CheckCircle2 className="h-4 w-4" />
+                    ) : (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    <AlertTitle>
+                      {pollError
+                        ? 'Pracenje SAGA statusa nije uspelo'
+                        : progressTerminal
+                          ? 'SAGA flow je zavrsen'
+                          : 'Izvrsavanje u toku...'}
+                    </AlertTitle>
+                    <AlertDescription>
+                      {pollError
+                        ? pollError
+                        : progressState.transaction.failureReason ||
+                          'Backend jos ne vraca currentPhase, pa se prikazuje pojednostavljen status spinner.'}
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <div className="space-y-4">
+                    <Progress value={progressValue} indicatorClassName="bg-gradient-to-r from-indigo-500 to-violet-600" />
+                    <div className="space-y-3">
+                      {SAGA_PHASES.map((label, index) => {
+                        const phaseNumber = index + 1;
+                        const completed = progressState.transaction.status === 'COMMITTED' || phaseNumber < currentPhaseIndex;
+                        const active =
+                          !progressTerminal &&
+                          !pollError &&
+                          phaseNumber === currentPhaseIndex;
+                        const failed =
+                          progressState.transaction.status === 'ABORTED' &&
+                          phaseNumber === currentPhaseIndex;
+
+                        return (
+                          <div
+                            key={label}
+                            className={`flex items-center justify-between rounded-lg border px-4 py-3 ${
+                              completed
+                                ? 'border-emerald-500/30 bg-emerald-500/5'
+                                : active
+                                  ? 'border-indigo-500/30 bg-indigo-500/5'
+                                  : failed
+                                    ? 'border-red-500/30 bg-red-500/5'
+                                    : 'border-border bg-background'
+                            }`}
+                          >
+                            <div className="flex items-center gap-3">
+                              {completed ? (
+                                <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                              ) : failed ? (
+                                <XCircle className="h-4 w-4 text-red-600" />
+                              ) : active ? (
+                                <Loader2 className="h-4 w-4 animate-spin text-indigo-600" />
+                              ) : (
+                                <span className="flex h-4 w-4 items-center justify-center rounded-full border text-[10px] font-semibold text-muted-foreground">
+                                  {phaseNumber}
+                                </span>
+                              )}
+                              <span className="text-sm font-medium">{label}</span>
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              {completed ? 'Zavrseno' : failed ? 'Prekinuto' : active ? 'U toku' : 'Na cekanju'}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {progressState.transaction.failureReason && (
+                  <Alert variant="destructive">
+                    <XCircle className="h-4 w-4" />
+                    <AlertTitle>SAGA je abortirana</AlertTitle>
+                    <AlertDescription>
+                      {progressState.transaction.failureReason}
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/src/pages/Otc/OtcOffersAndContractsPage.test.tsx
+++ b/src/pages/Otc/OtcOffersAndContractsPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import OtcOffersAndContractsPage from './OtcOffersAndContractsPage';
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'stefan.jovanovic@gmail.com',
+      username: 'client-1',
+      firstName: 'Stefan',
+      lastName: 'Jovanovic',
+      permissions: [],
+    },
+    isAdmin: false,
+    isAgent: false,
+    isSupervisor: false,
+  }),
+}));
+
+vi.mock('@/services/otcService', () => ({
+  default: {
+    listMyActiveOffers: vi.fn(),
+    listMyContracts: vi.fn(),
+    acceptOffer: vi.fn(),
+    declineOffer: vi.fn(),
+    counterOffer: vi.fn(),
+    exerciseContract: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/interbankOtcService', () => ({
+  default: {
+    listMyContracts: vi.fn(),
+    exerciseContract: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/accountService', () => ({
+  accountService: {
+    getMyAccounts: vi.fn(),
+    getBankAccounts: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/notify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import otcService from '@/services/otcService';
+import interbankOtcService from '@/services/interbankOtcService';
+import { accountService } from '@/services/accountService';
+
+const mockedOtcService = vi.mocked(otcService);
+const mockedInterbankOtcService = vi.mocked(interbankOtcService);
+const mockedAccountService = vi.mocked(accountService);
+
+describe('OtcOffersAndContractsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedOtcService.listMyActiveOffers.mockResolvedValue([]);
+    mockedOtcService.listMyContracts.mockResolvedValue([]);
+    mockedInterbankOtcService.listMyContracts.mockResolvedValue([]);
+    mockedAccountService.getMyAccounts.mockResolvedValue([] as never);
+  });
+
+  it('renders the local otc tabs by default and keeps the local view visible', async () => {
+    render(<OtcOffersAndContractsPage />);
+
+    expect(await screen.findByText('Moji aktivni pregovori')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Sklopljeni ugovori \(inter-bank\)/i })).toBeInTheDocument();
+    expect(mockedInterbankOtcService.listMyContracts).not.toHaveBeenCalled();
+  });
+
+  it('loads the remote contracts tab on demand', async () => {
+    const user = userEvent.setup();
+    render(<OtcOffersAndContractsPage />);
+
+    await screen.findByText('Moji aktivni pregovori');
+    await user.click(screen.getByRole('tab', { name: /Sklopljeni ugovori \(inter-bank\)/i }));
+
+    await waitFor(() => {
+      expect(mockedInterbankOtcService.listMyContracts).toHaveBeenCalledWith(undefined);
+    });
+    expect(await screen.findByText('Sklopljeni inter-bank ugovori')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Otc/OtcOffersAndContractsPage.tsx
+++ b/src/pages/Otc/OtcOffersAndContractsPage.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/table';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { formatAmount, formatDateTime, asArray, getErrorMessage } from '@/utils/formatters';
+import OtcInterBankContractsTab from './OtcInterBankContractsTab';
 
 const CONTRACT_STATUS_LABEL: Record<string, string> = {
   ACTIVE: 'Aktivan',
@@ -86,7 +87,7 @@ function computeOfferDeviation(
   };
 }
 
-type Tab = 'offers' | 'contracts';
+type Tab = 'offers' | 'contracts' | 'contracts-remote';
 
 export default function OtcOffersAndContractsPage() {
   const { isAdmin, isAgent, isSupervisor } = useAuth();
@@ -271,14 +272,21 @@ export default function OtcOffersAndContractsPage() {
         </div>
       </div>
 
-      <div className="flex gap-1 bg-muted/60 dark:bg-slate-800/60 p-1 rounded-xl border border-border/50 w-fit">
+      <div
+        className="flex gap-1 bg-muted/60 dark:bg-slate-800/60 p-1 rounded-xl border border-border/50 w-fit"
+        role="tablist"
+        aria-label="OTC ponude i ugovori tabovi"
+      >
         <button
+          type="button"
           onClick={() => setTab('offers')}
           className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-all ${
             tab === 'offers'
               ? 'bg-gradient-to-r from-indigo-500 to-violet-600 text-white shadow-md shadow-indigo-500/25'
               : 'text-muted-foreground hover:text-foreground'
           }`}
+          role="tab"
+          aria-selected={tab === 'offers'}
         >
           Aktivne ponude
           {activeOffers.length > 0 && (
@@ -288,14 +296,30 @@ export default function OtcOffersAndContractsPage() {
           )}
         </button>
         <button
+          type="button"
           onClick={() => setTab('contracts')}
           className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-all ${
             tab === 'contracts'
               ? 'bg-gradient-to-r from-indigo-500 to-violet-600 text-white shadow-md shadow-indigo-500/25'
               : 'text-muted-foreground hover:text-foreground'
           }`}
+          role="tab"
+          aria-selected={tab === 'contracts'}
         >
           Sklopljeni ugovori
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('contracts-remote')}
+          className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-all ${
+            tab === 'contracts-remote'
+              ? 'bg-gradient-to-r from-indigo-500 to-violet-600 text-white shadow-md shadow-indigo-500/25'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          role="tab"
+          aria-selected={tab === 'contracts-remote'}
+        >
+          Sklopljeni ugovori (inter-bank)
         </button>
       </div>
 
@@ -608,6 +632,8 @@ export default function OtcOffersAndContractsPage() {
           </CardContent>
         </Card>
       )}
+
+      {tab === 'contracts-remote' && <OtcInterBankContractsTab />}
 
       {accounts.length === 0 && (
         <Alert variant="warning">

--- a/src/types/celina4.ts
+++ b/src/types/celina4.ts
@@ -210,6 +210,7 @@ export interface InterbankTransaction {
   transactionId: string;
   type: InterbankTransactionType;
   status: InterbankPaymentStatus;
+  currentPhase?: string | null;
   senderBankCode: string;
   receiverBankCode: string;
   amount?: number | null;


### PR DESCRIPTION
## Description

Implemented the **OTC inter-bank contracts** flow on `OtcOffersAndContractsPage`, including the SAGA-based exercise flow for active inter-bank option contracts.

This change adds support for viewing inter-bank OTC contracts, filtering them by status, opening an exercise preview dialog, and tracking SAGA progress until the transaction reaches a terminal state.

## Included Changes

- implemented `OtcInterBankContractsTab`
- extended `OtcOffersAndContractsPage` with the `Sklopljeni ugovori (inter-bank)` tab
- added support for SAGA progress tracking with polling
- added fallback progress UI when backend does not return `currentPhase`
- extended `InterbankTransaction` typing with optional `currentPhase`

## Behavior Covered

- loads contracts via `interbankOtcService.listMyContracts()`
- supports filtering by:
  - `ALL`
  - `ACTIVE`
  - `EXERCISED`
  - `EXPIRED`
- shows `Iskoristi` only when:
  - contract is `ACTIVE`
  - current user is the buyer
  - `settlementDate > today`
- opens a confirmation dialog with:
  - strike total (`strikePrice * quantity`)
  - current market value
  - projected profit
  - account selector for payment
- confirms exercise through:
  - `interbankOtcService.exerciseContract(contractId, accountId)`
- opens a progress modal for SAGA execution
- polls every 3 seconds until transaction reaches:
  - `COMMITTED`
  - `ABORTED`
  - `STUCK`
- shows all 5 phases when `currentPhase` is available:
  - `Rezervacija sredstava`
  - `Rezervacija hartija`
  - `Transfer`
  - `Prenos vlasnistva`
  - `Finalizacija`
- falls back to a simple “in progress” spinner when `currentPhase` is not available
- displays `failureReason` when the SAGA flow is aborted

## Tests

Added/updated tests for this scope:

- `src/pages/Otc/OtcInterBankContractsTab.test.tsx`
- `src/pages/Otc/OtcOffersAndContractsPage.test.tsx`

Updated Cypress coverage in Elena TODO sections:

- `cypress/e2e/celina4-mock.cy.ts`
  - implemented `S46-S50` for inter-bank contracts and SAGA flow
- `cypress/e2e/celina4-live.cy.ts`
  - kept `L31-L33` skipped because backend endpoints are still not implemented

## Validation

Verified with:
- `vitest` passing (`7/7`)
- `TypeScript` clean
- `ESLint` clean

## Live Cypress Note

Live inter-bank contracts/SAGA scenarios are currently backend-blocked.

The backend still returns `400` for inter-bank OTC contracts/exercise endpoints because the relevant controller/service implementation is still TODO, so the live Cypress cases remain skipped by design.