### PR TITLE
feat(otc): role filter za inter-bank discovery (closes #95)

### DIFF
--- a/src/pages/Otc/OtcInterBankDiscoveryTab.test.tsx
+++ b/src/pages/Otc/OtcInterBankDiscoveryTab.test.tsx
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '@/test/test-utils';
 import OtcInterBankDiscoveryTab from './OtcInterBankDiscoveryTab';
+import type { OtcInterbankListing } from '@/types/celina4';
 
 const mockListRemoteListings = vi.fn();
 const mockCreateOffer = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
+const mockUseAuth = vi.fn();
 
 vi.mock('@/services/interbankOtcService', () => ({
   default: {
@@ -22,6 +24,14 @@ vi.mock('@/lib/notify', () => ({
     error: (...args: unknown[]) => mockToastError(...args),
   },
 }));
+
+vi.mock('@/context/AuthContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/AuthContext')>();
+  return {
+    ...actual,
+    useAuth: () => mockUseAuth(),
+  };
+});
 
 describe('OtcInterBankDiscoveryTab', () => {
   const remoteListings = [
@@ -41,6 +51,9 @@ describe('OtcInterBankDiscoveryTab', () => {
     vi.clearAllMocks();
     mockListRemoteListings.mockResolvedValue(remoteListings);
     mockCreateOffer.mockResolvedValue({ offerId: 'remote-offer-1' });
+    // Default: klijent (a defensive fallback omogucuje da listings bez
+    // sellerRole-a budu prikazani).
+    mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: false });
   });
 
   it('loads and renders remote listings on mount', async () => {
@@ -104,5 +117,145 @@ describe('OtcInterBankDiscoveryTab', () => {
     });
 
     expect(mockToastSuccess).toHaveBeenCalledWith('Inter-bank ponuda je uspesno poslata.');
+  });
+
+  // ─── Spec Celina 5 (Nova) §840-848 — Issue #95 role filter ───
+  describe('role filter', () => {
+    const makeListing = (
+      overrides: Partial<OtcInterbankListing> & { ticker?: string } = {},
+    ): OtcInterbankListing => ({
+      bankCode: overrides.bankCode ?? '111',
+      sellerPublicId: overrides.sellerPublicId ?? `seller-${overrides.ticker ?? 'AAPL'}`,
+      sellerName: overrides.sellerName ?? 'Marija Markovic',
+      listingTicker: overrides.ticker ?? overrides.listingTicker ?? 'AAPL',
+      listingName: overrides.listingName ?? 'Apple Inc.',
+      listingCurrency: overrides.listingCurrency ?? 'USD',
+      currentPrice: overrides.currentPrice ?? 175,
+      availableQuantity: overrides.availableQuantity ?? 50,
+      sellerRole: overrides.sellerRole,
+    });
+
+    it('hides EMPLOYEE listings from a CLIENT user', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: false });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'MSFT', sellerRole: 'EMPLOYEE' }),
+        makeListing({ ticker: 'GOOG', sellerRole: 'CLIENT' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText('GOOG')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
+      expect(screen.getByTestId('hidden-by-role-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('role-filter-badge')).toHaveTextContent('Klijenti');
+    });
+
+    it('hides CLIENT listings from a SUPERVIZOR user', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: true });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'MSFT', sellerRole: 'EMPLOYEE' }),
+        makeListing({ ticker: 'TSLA', sellerRole: 'EMPLOYEE' }),
+        makeListing({ ticker: 'GOOG', sellerRole: 'CLIENT' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('MSFT')).toBeInTheDocument();
+        expect(screen.getByText('TSLA')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
+      expect(screen.queryByText('GOOG')).not.toBeInTheDocument();
+      expect(screen.getByTestId('hidden-by-role-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('role-filter-badge')).toHaveTextContent('Aktuari');
+    });
+
+    it('hides CLIENT listings from an AGENT user', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: true, isSupervisor: false });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'MSFT', sellerRole: 'EMPLOYEE' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('MSFT')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
+    });
+
+    it('shows listings without sellerRole as defensive fallback (with warning)', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: false });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'MSFT' }),
+        makeListing({ ticker: 'TSLA', sellerRole: 'EMPLOYEE' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+        expect(screen.getByText('MSFT')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('TSLA')).not.toBeInTheDocument();
+      expect(screen.getByTestId('hidden-by-role-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('unknown-role-count')).toHaveTextContent('1');
+    });
+
+    it('does not show role filter hint when nothing is hidden and all listings have known role', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: false });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'GOOG', sellerRole: 'CLIENT' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('AAPL')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('role-filter-hint')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('hidden-by-role-count')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('unknown-role-count')).not.toBeInTheDocument();
+    });
+
+    it('shows empty-state copy when ALL listings were hidden by role filter', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: false, isAgent: false, isSupervisor: false });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'MSFT', sellerRole: 'EMPLOYEE' }),
+        makeListing({ ticker: 'TSLA', sellerRole: 'EMPLOYEE' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Sve\s+2\s+dostupnih ponuda odgovara drugoj roli/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
+      expect(screen.queryByText('TSLA')).not.toBeInTheDocument();
+    });
+
+    it('admin sees EMPLOYEE listings (admin is implicitly supervisor)', async () => {
+      mockUseAuth.mockReturnValue({ isAdmin: true, isAgent: false, isSupervisor: true });
+      mockListRemoteListings.mockResolvedValue([
+        makeListing({ ticker: 'AAPL', sellerRole: 'CLIENT' }),
+        makeListing({ ticker: 'MSFT', sellerRole: 'EMPLOYEE' }),
+      ]);
+
+      render(<OtcInterBankDiscoveryTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText('MSFT')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('AAPL')).not.toBeInTheDocument();
+      expect(screen.getByTestId('role-filter-badge')).toHaveTextContent('Aktuari');
+    });
   });
 });

--- a/src/pages/Otc/OtcInterBankDiscoveryTab.tsx
+++ b/src/pages/Otc/OtcInterBankDiscoveryTab.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useCallback, useEffect, useState } from 'react';
-import { RefreshCw, TrendingUp } from 'lucide-react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { Info, RefreshCw, TrendingUp } from 'lucide-react';
 import { toast } from '@/lib/notify';
 import interbankOtcService from '@/services/interbankOtcService';
 import type { CreateOtcInterbankOfferRequest, OtcInterbankListing } from '@/types/celina4';
+import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -35,23 +36,24 @@ const getListingKey = (listing: OtcInterbankListing) =>
   `${listing.bankCode}:${listing.sellerPublicId}:${listing.listingTicker}`;
 
 /*
-  P8 — TODO ROLE FILTER (Spec Celina 5 (Nova) §840-848):
+  ROLE FILTER (Spec Celina 5 (Nova) §840-848):
   "Klijenti vide ponude Klijenata, Aktuari vide ponude Aktuara."
 
-  Trenutno: FE prikazuje sve ponude koje BE vrati. Posto profesorov protokol
-  HTML §3.1 (`GET /public-stock`) ne nudi role discovery (`PublicStock.sellers`
-  ima samo `ForeignBankId` koji je opaque), filter se moze uraditi tek na
-  jedan od ova 4 nacina (vidi InterbankClient.fetchPublicStocks TODO blok):
-    a) BE filter sa /user/{rn}/{id} po-seller (sporo, N+1)
-    b) FE filter ako partner banka u extension polju vrati seller userRole
-    c) Konvencija ID prefiksa (npr. "C-" / "E-")
-    d) Postaviti pri acceptOffer-u: server vraca 400 ako role-mismatch
-
-  PRIVREMENO: prikazujemo sve. Kupac koji pokusa cross-role accept ce dobiti
-  IllegalArgumentException 400 iz `OtcService.ensureSameRoleParticipants` — vec
-  pokriveno kroz P2.
+  Strategija (resolved per Issue #95):
+  - Defensive FE filter po opcionom `OtcInterbankListing.sellerRole` polju
+    koje partner banke mogu da vrate kao extension u `GET /public-stock`.
+  - Ako polje POSTOJI: izbacujemo cross-role listinge (klijent ne vidi
+    EMPLOYEE, zaposleni ne vidi CLIENT).
+  - Ako polje NE postoji: prikazujemo listing (defensive fallback) i oslanjamo
+    se na BE acceptOffer guard (`OtcService.ensureSameRoleParticipants`) koji
+    vraca 400 za cross-role pokusaje. UI ima info badge koji upozorava korisnika
+    da ce server odbiti kupovinu ako je rola pogresna.
+  - UI takodje pokazuje koliko je listinga sakriveno filterom.
 */
 export default function OtcInterBankDiscoveryTab() {
+  const { isAdmin, isAgent, isSupervisor } = useAuth();
+  const myRole: 'CLIENT' | 'EMPLOYEE' = isAdmin || isAgent || isSupervisor ? 'EMPLOYEE' : 'CLIENT';
+
   const [listings, setListings] = useState<OtcInterbankListing[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -63,6 +65,16 @@ export default function OtcInterBankDiscoveryTab() {
     premium: '',
     settlementDate: addDaysISO(7),
   });
+
+  const visibleListings = useMemo(
+    () => listings.filter((l) => !l.sellerRole || l.sellerRole === myRole),
+    [listings, myRole],
+  );
+  const hiddenByRoleCount = listings.length - visibleListings.length;
+  const unknownRoleCount = useMemo(
+    () => visibleListings.filter((l) => !l.sellerRole).length,
+    [visibleListings],
+  );
 
   const refresh = useCallback(async (mode: 'initial' | 'manual' | 'post-submit' = 'initial') => {
     if (mode === 'initial') {
@@ -155,7 +167,19 @@ export default function OtcInterBankDiscoveryTab() {
       <CardHeader className="flex flex-row items-center justify-between gap-4">
         <CardTitle className="flex items-center gap-2">
           <div className="h-5 w-1 rounded-full bg-gradient-to-b from-indigo-500 to-violet-600" />
-          Javno dostupne akcije iz drugih banaka ({listings.length})
+          Javno dostupne akcije iz drugih banaka ({visibleListings.length})
+          <Badge
+            variant="outline"
+            className="ml-2 font-normal"
+            data-testid="role-filter-badge"
+            title={
+              myRole === 'CLIENT'
+                ? 'Vidis samo ponude koje su postavili klijenti drugih banaka.'
+                : 'Vidis samo ponude koje su postavili aktuari drugih banaka.'
+            }
+          >
+            {myRole === 'CLIENT' ? 'Klijenti' : 'Aktuari'}
+          </Badge>
         </CardTitle>
         <Button
           type="button"
@@ -169,20 +193,48 @@ export default function OtcInterBankDiscoveryTab() {
         </Button>
       </CardHeader>
       <CardContent>
+        {!loading && (hiddenByRoleCount > 0 || unknownRoleCount > 0) && (
+          <div
+            className="mb-3 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200"
+            data-testid="role-filter-hint"
+          >
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="space-y-0.5">
+              {hiddenByRoleCount > 0 && (
+                <p>
+                  <span data-testid="hidden-by-role-count">{hiddenByRoleCount}</span>{' '}
+                  {hiddenByRoleCount === 1 ? 'ponuda je sakrivena' : 'ponuda je sakriveno'}{' '}
+                  jer{' '}
+                  {hiddenByRoleCount === 1 ? 'odgovara' : 'odgovaraju'}{' '}
+                  drugoj roli korisnika.
+                </p>
+              )}
+              {unknownRoleCount > 0 && (
+                <p>
+                  Za <span data-testid="unknown-role-count">{unknownRoleCount}</span>{' '}
+                  {unknownRoleCount === 1 ? 'ponudu' : 'ponuda'} partner banka nije vratila
+                  rolu prodavca; pokusaj kupovine ce biti odbijen ako rola ne odgovara.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
         {loading ? (
           <div className="space-y-2">
             {Array.from({ length: 4 }).map((_, i) => (
               <div key={i} className="h-14 animate-pulse rounded bg-muted/50" />
             ))}
           </div>
-        ) : listings.length === 0 ? (
+        ) : visibleListings.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
               <TrendingUp className="h-6 w-6 text-muted-foreground" />
             </div>
             <p className="font-medium">Nema dostupnih inter-bank OTC ponuda</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Trenutno nema javnih listinga iz partnerskih banaka za vas profil trgovanja.
+              {hiddenByRoleCount > 0
+                ? `Sve ${hiddenByRoleCount} dostupnih ponuda odgovara drugoj roli korisnika.`
+                : 'Trenutno nema javnih listinga iz partnerskih banaka za vas profil trgovanja.'}
             </p>
           </div>
         ) : (
@@ -198,7 +250,7 @@ export default function OtcInterBankDiscoveryTab() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {listings.map((listing) => {
+              {visibleListings.map((listing) => {
                 const listingKey = getListingKey(listing);
                 const isOpen = openedListingKey === listingKey;
 

--- a/src/types/celina4.ts
+++ b/src/types/celina4.ts
@@ -124,6 +124,15 @@ export interface OtcInterbankListing {
   listingCurrency: string;
   currentPrice: number;
   availableQuantity: number;
+  /**
+   * Spec Celina 5 (Nova) §840-848: "Klijenti vide ponude Klijenata, Aktuari
+   * vide ponude Aktuara." Polje je opciono jer profesorov bank-to-bank protokol
+   * §3.1 (`GET /public-stock`) ne nudi role discovery — partner banke koje
+   * dodaju ovo polje kao extension nas FE moze precizno filtrirati. Ako polje
+   * nije prisutno, FE prikazuje listing (defensive fallback) i oslanja se na
+   * BE acceptOffer guard koji vraca 400 za cross-role pokusaje.
+   */
+  sellerRole?: 'CLIENT' | 'EMPLOYEE';
 }
 
 export type OtcInterbankOfferStatus = 'ACTIVE' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';


### PR DESCRIPTION
## Summary

Spec **Celina 5 (Nova) §840-848**: "Klijenti vide ponude Klijenata, Aktuari vide ponude Aktuara."

Implementira role filter na `OtcInterBankDiscoveryTab` koristeci defensive strategy iz Issue #95 (opcija b — FE filter ako partner banka u extension polju vrati seller userRole).

## Strategija

- Defensive FE filter po opcionom `OtcInterbankListing.sellerRole` polju koje partner banke mogu da vrate kao extension u `GET /public-stock`.
- Ako polje **postoji**: izbacujemo cross-role listinge.
- Ako polje **ne postoji**: prikazujemo listing (defensive fallback) i oslanjamo se na BE acceptOffer guard (`OtcService.ensureSameRoleParticipants`) koji vraca 400 za cross-role pokusaje (vec implementirano u P2).

## UI dodaci

- Badge "Klijenti" / "Aktuari" pored counter-a u CardHeader-u sa tooltip-om.
- Amber info banner sa info ikonom kad ima sakrivenih ili unknown-role ponuda.
- Empty state copy razlikuje "nema ponuda" vs "sve sakrivene filterom".

## Test coverage

Dodato 7 novih vitest testova u `OtcInterBankDiscoveryTab.test.tsx`:
- klijent vidi samo CLIENT listings
- supervizor vidi samo EMPLOYEE listings
- agent vidi samo EMPLOYEE listings
- admin (implicitni supervizor) vidi samo EMPLOYEE listings
- defensive fallback za listings bez sellerRole
- nema info hint-a kad nista nije sakriveno
- empty state copy kad su svi sakriveni filterom

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx eslint .` → 0 errors (1 pre-existing warning u MyFundsTab.tsx, ne tice se ovog PR-a)
- [x] `npm test` → 1350/1350 passed (1343 pre + 7 novih)
- [ ] CI Cypress mocked + live prolaze
- [ ] Build Docker prolazi

Closes #95