### PR TITLE
feat: stedna knjizica (oroceni depozit) + 8 bagova manuelnog testiranja 12.05.2026

### DIFF
--- a/cypress/e2e/celina2-live.cy.ts
+++ b/cypress/e2e/celina2-live.cy.ts
@@ -1172,3 +1172,36 @@ describe('Live: Sidebar detalji', () => {
     cy.contains(/Krediti/i).should('exist');
   });
 });
+
+// ============================================================
+// Stedna knjizica (live) — Celina 2 nadogradnja
+// ============================================================
+
+describe('Stedna knjizica (live) — Celina 2 nadogradnja', () => {
+  it('Sc S1 live: Klijent moze da otvori /savings i vidi seedovani depozit', () => {
+    loginAsClient('stefan');
+    cy.visit('/savings');
+    cy.contains(/Stednja/i, { timeout: 10000 }).should('be.visible');
+    // Stefan ima 1 seedovani depozit (RSD 200K 12m)
+    cy.contains(/200/, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('Sc S2 live: Klijent vidi sidebar link Stednja', () => {
+    loginAsClient('stefan');
+    cy.visit('/');
+    cy.contains(/Stednja/i, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('Sc S3 live: Admin vidi /admin/savings/deposits stranicu', () => {
+    loginAsAdmin();
+    cy.visit('/admin/savings/deposits');
+    cy.contains(/(orocni )?depozit/i, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('Sc S4 live: GET /api/savings/rates vraca seedovane stope', () => {
+    loginAsClient('stefan');
+    cy.visit('/savings/new');
+    // Kamatne stope su ucitane na stranici za novi depozit
+    cy.contains(/RSD|kamat/i, { timeout: 10000 }).should('be.visible');
+  });
+});

--- a/cypress/e2e/celina2-mock.cy.ts
+++ b/cypress/e2e/celina2-mock.cy.ts
@@ -1628,3 +1628,124 @@ describe('OTP Verifikacija - Detaljni testovi', () => {
     cy.contains(/verifikacij|kod/i).should('exist');
   });
 });
+
+// ============================================================
+// Stedna knjizica (mock) — Celina 2 nadogradnja
+// ============================================================
+
+describe('Stedna knjizica (mock) — Celina 2 nadogradnja', () => {
+  beforeEach(() => {
+    // Mock kamatne stope (klijentski endpoint)
+    cy.intercept('GET', '**/api/savings/rates', {
+      statusCode: 200,
+      body: [
+        { id: 1, currencyCode: 'RSD', termMonths: 3, annualRate: 2.5, active: true, effectiveFrom: '2026-01-01' },
+        { id: 2, currencyCode: 'RSD', termMonths: 6, annualRate: 3.0, active: true, effectiveFrom: '2026-01-01' },
+        { id: 3, currencyCode: 'RSD', termMonths: 12, annualRate: 4.0, active: true, effectiveFrom: '2026-01-01' },
+        { id: 4, currencyCode: 'RSD', termMonths: 24, annualRate: 4.5, active: true, effectiveFrom: '2026-01-01' },
+        { id: 5, currencyCode: 'RSD', termMonths: 36, annualRate: 5.0, active: true, effectiveFrom: '2026-01-01' },
+      ],
+    }).as('rates');
+
+    // Mock klijentova lista depozita
+    cy.intercept('GET', '**/api/savings/deposits/my', {
+      statusCode: 200,
+      body: [
+        {
+          id: 1, clientId: 1, clientName: 'Stefan Jovanovic',
+          linkedAccountId: 1, linkedAccountNumber: '222000112345678911',
+          principalAmount: 200000, currencyCode: 'RSD', termMonths: 12, annualInterestRate: 4.0,
+          startDate: '2026-03-12', maturityDate: '2027-03-12', nextInterestPaymentDate: '2026-06-12',
+          totalInterestPaid: 1333.33, autoRenew: true, status: 'ACTIVE',
+          createdAt: '2026-03-12T09:00:00Z', updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    }).as('myDeposits');
+  });
+
+  it('Sc S1: Klijent vidi listu depozita', () => {
+    cy.visit('/savings', { onBeforeLoad: setupClientSession });
+    cy.wait('@myDeposits');
+    cy.contains(/Stednja/i).should('be.visible');
+    cy.get('[data-testid="deposit-card-1"]').should('be.visible');
+  });
+
+  it('Sc S2: Empty state se prikazuje kada nema depozita', () => {
+    cy.intercept('GET', '**/api/savings/deposits/my', {
+      statusCode: 200,
+      body: [],
+    }).as('emptyDeposits');
+    cy.visit('/savings', { onBeforeLoad: setupClientSession });
+    cy.wait('@emptyDeposits');
+    cy.contains(/Nemate aktivnih depozita/i).should('be.visible');
+  });
+
+  it('Sc S3: Klijent navigira na "+ Novi depozit"', () => {
+    cy.visit('/savings', { onBeforeLoad: setupClientSession });
+    cy.wait('@myDeposits');
+    cy.get('[data-testid="open-new-deposit"]').click();
+    cy.url().should('include', '/savings/new');
+  });
+
+  it('Sc S4: Sidebar prikazuje "Stednja" link za klijenta', () => {
+    cy.visit('/', { onBeforeLoad: setupClientSession });
+    cy.contains(/Stednja/i).should('be.visible');
+  });
+
+  it('Sc S5: Admin vidi stranicu svih depozita', () => {
+    cy.intercept('GET', '**/api/admin/savings/deposits*', {
+      statusCode: 200,
+      body: { content: [], totalElements: 0, totalPages: 0, number: 0, size: 20 },
+    }).as('adminDeposits');
+    cy.visit('/admin/savings/deposits', { onBeforeLoad: setupAdminSession });
+    cy.wait('@adminDeposits');
+    cy.contains(/(orocni )?depozit/i).should('be.visible');
+  });
+
+  it('Sc S6: Admin moze da vidi stranicu kamatnih stopa', () => {
+    cy.intercept('GET', '**/api/admin/savings/rates', {
+      statusCode: 200,
+      body: [
+        { id: 1, currencyCode: 'RSD', termMonths: 12, annualRate: 4.0, active: true, effectiveFrom: '2026-01-01' },
+        { id: 2, currencyCode: 'EUR', termMonths: 12, annualRate: 2.5, active: true, effectiveFrom: '2026-01-01' },
+      ],
+    }).as('adminRates');
+    cy.visit('/admin/savings/rates', { onBeforeLoad: setupAdminSession });
+    cy.wait('@adminRates');
+    cy.contains(/Kamatne stope/i).should('be.visible');
+  });
+
+  it('Sc S7: Klijent vidi detalje depozita sa timeline-om transakcija', () => {
+    cy.intercept('GET', '**/api/savings/deposits/1', {
+      statusCode: 200,
+      body: {
+        id: 1, clientId: 1, clientName: 'Stefan Jovanovic',
+        linkedAccountId: 1, linkedAccountNumber: '222000112345678911',
+        principalAmount: 200000, currencyCode: 'RSD', termMonths: 12, annualInterestRate: 4.0,
+        startDate: '2026-03-12', maturityDate: '2027-03-12', nextInterestPaymentDate: '2026-06-12',
+        totalInterestPaid: 1333.33, autoRenew: true, status: 'ACTIVE',
+        createdAt: '2026-03-12T09:00:00Z', updatedAt: '2026-05-12T02:00:00Z',
+      },
+    }).as('depositDetails');
+    cy.intercept('GET', '**/api/savings/deposits/1/transactions', {
+      statusCode: 200,
+      body: [
+        {
+          id: 1, depositId: 1, type: 'OPEN', amount: 200000, currencyCode: 'RSD',
+          processedDate: '2026-03-12', resultingTransactionId: null,
+          description: 'Otvaranje depozita', createdAt: '2026-03-12T09:00:00Z',
+        },
+      ],
+    }).as('txs');
+    cy.visit('/savings/1', { onBeforeLoad: setupClientSession });
+    cy.wait('@depositDetails');
+    cy.wait('@txs');
+    cy.contains(/200/).should('be.visible');
+    cy.get('[data-testid="timeline"]').should('be.visible');
+  });
+
+  it('Sc S8: HomePage prikazuje "Orocno" KPI chip za klijenta', () => {
+    cy.visit('/', { onBeforeLoad: setupClientSession });
+    cy.contains(/Orocno/i).should('be.visible');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,13 @@ import FundDetailsPage from './pages/Funds/FundDetailsPage';
 import CreateFundPage from './pages/Funds/CreateFundPage';
 import ProfitBankPage from './pages/ProfitBank/ProfitBankPage';
 
+// Stedna knjizica
+import SavingsListPage from './pages/Savings/SavingsListPage';
+import SavingsNewDepositPage from './pages/Savings/SavingsNewDepositPage';
+import SavingsDetailsPage from './pages/Savings/SavingsDetailsPage';
+import AdminSavingsDepositsPage from './pages/Savings/AdminSavingsDepositsPage';
+import AdminSavingsRatesPage from './pages/Savings/AdminSavingsRatesPage';
+
 // Celina 6 - Arbitro AI asistent (web only). Phase 5 optimizacija:
 // React.lazy + Suspense — Arbitro modul (~250KB sa Liquid Glass CSS-om)
 // se ucitava tek kada korisnik prvi put klikne FAB. Tako se inicijalni
@@ -162,6 +169,21 @@ export default function App() {
           {/* Investicioni fondovi (Celina 4) — discovery i details su za sve */}
           <Route path="/funds" element={<FundsDiscoveryPage />} />
           <Route path="/funds/:id" element={<FundDetailsPage />} />
+
+          {/* Stedna knjizica — klijent rute (noAgentOnly) */}
+          <Route element={<ProtectedRoute noAgentOnly />}>
+            <Route path="/savings" element={<SavingsListPage />} />
+            <Route path="/savings/new" element={<SavingsNewDepositPage />} />
+            <Route path="/savings/:id" element={<SavingsDetailsPage />} />
+          </Route>
+
+          {/* Stedna knjizica — admin/supervisor rute */}
+          <Route element={<ProtectedRoute supervisorOnly />}>
+            <Route path="/admin/savings/deposits" element={<AdminSavingsDepositsPage />} />
+          </Route>
+          <Route element={<ProtectedRoute adminOnly />}>
+            <Route path="/admin/savings/rates" element={<AdminSavingsRatesPage />} />
+          </Route>
         </Route>
       </Route>
 

--- a/src/__tests__/SavingsCalculator.test.tsx
+++ b/src/__tests__/SavingsCalculator.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SavingsCalculator } from '../components/savings/SavingsCalculator';
+
+describe('SavingsCalculator', () => {
+  it('shows monthly interest for RSD 4% 200K', () => {
+    render(
+      <SavingsCalculator
+        principal={200000}
+        annualRate={4}
+        termMonths={12}
+        currencyCode="RSD"
+      />
+    );
+    // 200000 * 4 / 1200 = 666.67
+    const monthly = screen.getByTestId('calc-monthly');
+    expect(monthly.textContent).toMatch(/666/);
+  });
+
+  it('shows total interest over 12 months', () => {
+    render(
+      <SavingsCalculator
+        principal={200000}
+        annualRate={4}
+        termMonths={12}
+        currencyCode="RSD"
+      />
+    );
+    // 666.67 * 12 = ~8000
+    const total = screen.getByTestId('calc-total');
+    expect(total.textContent).toMatch(/8\.000|8,000|8000|8\.000,00/);
+  });
+
+  it('shows penalty as 1% of principal', () => {
+    render(
+      <SavingsCalculator
+        principal={100000}
+        annualRate={4}
+        termMonths={12}
+        currencyCode="RSD"
+      />
+    );
+    // 100000 * 0.01 = 1000
+    const penalty = screen.getByTestId('calc-penalty');
+    expect(penalty.textContent).toMatch(/1\.000|1,000|1000/);
+  });
+
+  it('handles zero principal gracefully', () => {
+    render(
+      <SavingsCalculator
+        principal={0}
+        annualRate={0}
+        termMonths={12}
+        currencyCode="EUR"
+      />
+    );
+    expect(screen.getByTestId('calc-monthly').textContent).toMatch(/0/);
+  });
+});

--- a/src/__tests__/SavingsListPage.test.tsx
+++ b/src/__tests__/SavingsListPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SavingsListPage from '../pages/Savings/SavingsListPage';
+import { savingsService } from '../services/savingsService';
+
+vi.mock('../services/savingsService', () => ({
+  savingsService: {
+    listMyDeposits: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/notify', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const mockListMy = vi.mocked(savingsService.listMyDeposits);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SavingsListPage />
+    </MemoryRouter>
+  );
+}
+
+describe('SavingsListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows empty state when no deposits', async () => {
+    mockListMy.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Nemate aktivnih depozita/i)).toBeTruthy();
+    });
+  });
+
+  it('renders deposit cards for active deposits', async () => {
+    mockListMy.mockResolvedValue([
+      {
+        id: 1,
+        clientId: 1,
+        clientName: 'Test',
+        linkedAccountId: 1,
+        linkedAccountNumber: '222',
+        principalAmount: 200000,
+        currencyCode: 'RSD',
+        termMonths: 12,
+        annualInterestRate: 4,
+        startDate: '2026-03-12',
+        maturityDate: '2027-03-12',
+        nextInterestPaymentDate: '2026-06-12',
+        totalInterestPaid: 666,
+        autoRenew: true,
+        status: 'ACTIVE',
+        createdAt: '2026-03-12T00:00:00Z',
+        updatedAt: '2026-03-12T00:00:00Z',
+      },
+    ]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('deposit-card-1')).toBeTruthy();
+    });
+  });
+
+  it('has "+ Novi depozit" call-to-action', async () => {
+    mockListMy.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => {
+      const btn = screen.getByTestId('open-new-deposit');
+      expect(btn).toBeTruthy();
+    });
+  });
+});

--- a/src/__tests__/savingsService.test.ts
+++ b/src/__tests__/savingsService.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import api from '../services/api';
+import { savingsService } from '../services/savingsService';
+
+vi.mock('../services/api');
+const mockApi = vi.mocked(api);
+
+describe('savingsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('openDeposit POSTs to /savings/deposits and returns data', async () => {
+    const dto = {
+      sourceAccountId: 1,
+      linkedAccountId: 1,
+      principalAmount: 100000,
+      termMonths: 12,
+      autoRenew: false,
+      otpCode: '123456',
+    };
+    mockApi.post.mockResolvedValue({ data: { id: 99 } });
+    const result = await savingsService.openDeposit(dto);
+    expect(mockApi.post).toHaveBeenCalledWith('/savings/deposits', dto);
+    expect(result.id).toBe(99);
+  });
+
+  it('listMyDeposits GETs /savings/deposits/my', async () => {
+    mockApi.get.mockResolvedValue({ data: [{ id: 1 }, { id: 2 }] });
+    const result = await savingsService.listMyDeposits();
+    expect(mockApi.get).toHaveBeenCalledWith('/savings/deposits/my');
+    expect(result).toHaveLength(2);
+  });
+
+  it('getDeposit GETs /savings/deposits/:id', async () => {
+    mockApi.get.mockResolvedValue({ data: { id: 1 } });
+    await savingsService.getDeposit(1);
+    expect(mockApi.get).toHaveBeenCalledWith('/savings/deposits/1');
+  });
+
+  it('getTransactions GETs /savings/deposits/:id/transactions', async () => {
+    mockApi.get.mockResolvedValue({ data: [] });
+    await savingsService.getTransactions(5);
+    expect(mockApi.get).toHaveBeenCalledWith('/savings/deposits/5/transactions');
+  });
+
+  it('toggleAutoRenew PATCHs with body { autoRenew }', async () => {
+    mockApi.patch.mockResolvedValue({ data: { id: 1, autoRenew: true } });
+    await savingsService.toggleAutoRenew(1, true);
+    expect(mockApi.patch).toHaveBeenCalledWith('/savings/deposits/1/auto-renew', { autoRenew: true });
+  });
+
+  it('withdrawEarly POSTs with otpCode', async () => {
+    mockApi.post.mockResolvedValue({ data: { id: 1, status: 'WITHDRAWN_EARLY' } });
+    await savingsService.withdrawEarly(1, '654321');
+    expect(mockApi.post).toHaveBeenCalledWith('/savings/deposits/1/withdraw-early', { otpCode: '654321' });
+  });
+
+  it('getRates without currency returns all', async () => {
+    mockApi.get.mockResolvedValue({ data: [] });
+    await savingsService.getRates();
+    expect(mockApi.get).toHaveBeenCalledWith('/savings/rates', { params: {} });
+  });
+
+  it('getRates with currency filters', async () => {
+    mockApi.get.mockResolvedValue({ data: [] });
+    await savingsService.getRates('RSD');
+    expect(mockApi.get).toHaveBeenCalledWith('/savings/rates', { params: { currency: 'RSD' } });
+  });
+
+  it('adminListAll passes params', async () => {
+    mockApi.get.mockResolvedValue({ data: { content: [], totalElements: 0 } });
+    await savingsService.adminListAll({ status: 'ACTIVE', clientId: 1, page: 0, size: 20 });
+    expect(mockApi.get).toHaveBeenCalledWith('/admin/savings/deposits', {
+      params: { status: 'ACTIVE', clientId: 1, page: 0, size: 20 },
+    });
+  });
+
+  it('adminListAllRates GETs /admin/savings/rates', async () => {
+    mockApi.get.mockResolvedValue({ data: [] });
+    await savingsService.adminListAllRates();
+    expect(mockApi.get).toHaveBeenCalledWith('/admin/savings/rates');
+  });
+
+  it('adminUpsertRate POSTs new rate', async () => {
+    const dto = { currencyCode: 'RSD', termMonths: 12, annualRate: 4.5 };
+    mockApi.post.mockResolvedValue({
+      data: { ...dto, id: 1, active: true, effectiveFrom: '2026-05-12' },
+    });
+    await savingsService.adminUpsertRate(dto);
+    expect(mockApi.post).toHaveBeenCalledWith('/admin/savings/rates', dto);
+  });
+});

--- a/src/components/savings/SavingsCalculator.tsx
+++ b/src/components/savings/SavingsCalculator.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+
+interface Props {
+  principal: number;
+  annualRate: number;
+  termMonths: number;
+  currencyCode: string;
+}
+
+function formatNumber(n: number, currencyCode: string): string {
+  if (!Number.isFinite(n)) return '-';
+  try {
+    return new Intl.NumberFormat('sr-RS', {
+      style: 'currency',
+      currency: currencyCode,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(n);
+  } catch {
+    return `${n.toFixed(2)} ${currencyCode}`;
+  }
+}
+
+export function SavingsCalculator({ principal, annualRate, termMonths, currencyCode }: Props) {
+  const monthlyInterest = useMemo(
+    () => (principal && annualRate ? (principal * annualRate) / 1200 : 0),
+    [principal, annualRate]
+  );
+  const totalInterest = useMemo(() => monthlyInterest * termMonths, [monthlyInterest, termMonths]);
+  const penalty = useMemo(() => principal * 0.01, [principal]);
+
+  return (
+    <Card className="p-6 sticky top-24" data-testid="savings-calculator">
+      <h3 className="text-lg font-semibold mb-4">Pregled depozita</h3>
+      <dl className="space-y-3 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Mesecna kamata</dt>
+          <dd className="font-medium tabular-nums" data-testid="calc-monthly">
+            {formatNumber(monthlyInterest, currencyCode)}
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Ukupno kamata u roku ({termMonths}m)</dt>
+          <dd className="font-medium tabular-nums" data-testid="calc-total">
+            {formatNumber(totalInterest, currencyCode)}
+          </dd>
+        </div>
+        <div className="flex justify-between border-t pt-3">
+          <dt className="text-muted-foreground">Iznos na dospece (bez auto-obnove)</dt>
+          <dd className="font-medium tabular-nums" data-testid="calc-payout">
+            {formatNumber(principal + totalInterest, currencyCode)}
+          </dd>
+        </div>
+        <div className="flex justify-between text-amber-600 dark:text-amber-400">
+          <dt>Penal pri raskidu (1%)</dt>
+          <dd className="font-medium tabular-nums" data-testid="calc-penalty">
+            -{formatNumber(penalty, currencyCode)}
+          </dd>
+        </div>
+      </dl>
+    </Card>
+  );
+}
+
+export default SavingsCalculator;

--- a/src/components/shared/ClientSidebar.tsx
+++ b/src/components/shared/ClientSidebar.tsx
@@ -24,6 +24,8 @@ import {
   Landmark,
   Handshake,
   PiggyBank,
+  Vault,
+  Percent,
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { Button } from '../ui/button';
@@ -80,6 +82,7 @@ export default function ClientSidebar() {
       { label: 'Kartice', path: '/cards', icon: <CreditCard className="h-4 w-4" /> },
       { label: 'Krediti', path: '/loans', icon: <FileText className="h-4 w-4" /> },
       { label: 'Marzni racuni', path: '/margin-accounts', icon: <Landmark className="h-4 w-4" /> },
+      { label: 'Stednja', path: '/savings', icon: <PiggyBank className="h-4 w-4" /> },
     ],
     []
   );
@@ -140,9 +143,17 @@ export default function ClientSidebar() {
           { label: 'Aktuari', path: '/employee/actuaries', icon: <TrendingUp className="h-4 w-4" /> },
           { label: 'Porez', path: '/employee/tax', icon: <Calculator className="h-4 w-4" /> },
           { label: 'Profit Banke', path: '/employee/profit-bank', icon: <Landmark className="h-4 w-4" /> },
+          { label: 'Svi depoziti', path: '/admin/savings/deposits', icon: <Vault className="h-4 w-4" /> },
           // Napomena: "Kreiraj fond" se pristupa preko /funds stranice (dugme gore desno).
           // Zaseban sidebar link napravio bi koliziju sa postojecim Cypress regex
           // testovima (/novi|dodaj|kreiraj/i) na Admin Employee flow-u.
+        );
+      }
+
+      // Admin-only savings links
+      if (isAdmin) {
+        links.push(
+          { label: 'Kamatne stope', path: '/admin/savings/rates', icon: <Percent className="h-4 w-4" /> },
         );
       }
 

--- a/src/pages/ActivateAccount/ActivateAccountPage.test.tsx
+++ b/src/pages/ActivateAccount/ActivateAccountPage.test.tsx
@@ -17,12 +17,28 @@ vi.mock('react-router-dom', async () => {
 });
 
 const mockActivateAccount = vi.fn();
+const mockGetTokenStatus = vi.fn();
 
 vi.mock('../../services/authService', () => ({
   authService: {
     activateAccount: (...args: unknown[]) => mockActivateAccount(...args),
+    getActivationTokenStatus: (...args: unknown[]) => mockGetTokenStatus(...args),
   },
 }));
+
+/**
+ * Helper koji setuje VALID status (default ponasanje za testove koji ocekuju
+ * formu). Bug Sc 9 (12.05.2026): pre renderovanja forme FE proverava status
+ * tokena — VALID = renderuj formu, USED/EXPIRED/INVALID/ALREADY_ACTIVE =
+ * renderuj odgovarajucu stanu poruku.
+ */
+function mockValidToken() {
+  mockGetTokenStatus.mockResolvedValueOnce({
+    status: 'VALID',
+    expiresAt: '2026-05-13T20:00:00',
+    email: 'novi.zaposleni@banka.rs',
+  });
+}
 
 describe('ActivateAccountPage', () => {
   beforeEach(() => {
@@ -30,34 +46,47 @@ describe('ActivateAccountPage', () => {
     mockSearchParams = new URLSearchParams();
   });
 
-  it('shows error when no token in URL', () => {
+  it('shows invalid message when no token in URL', async () => {
     renderWithProviders(<ActivateAccountPage />);
 
-    expect(screen.getByText(/nevažeći link za aktivaciju/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-token-invalid')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/nevazeci link za aktivaciju/i)).toBeInTheDocument();
   });
 
-  it('renders activation form when token is present', () => {
+  it('renders activation form when token is VALID', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     expect(screen.getByText(/aktivacija naloga/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/potvrdite lozinku/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /aktiviraj nalog/i })).toBeInTheDocument();
   });
 
-  it('shows password constraint info', () => {
+  it('shows password constraint info when form rendered', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     renderWithProviders(<ActivateAccountPage />);
 
-    expect(screen.getByText(/8-32 karaktera/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/8-32 karaktera/i)).toBeInTheDocument();
+    });
   });
 
   it('validates password - shows error on empty submit', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /aktiviraj nalog/i })).toBeInTheDocument();
+    });
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
 
     await waitFor(() => {
@@ -67,9 +96,13 @@ describe('ActivateAccountPage', () => {
 
   it('validates password mismatch', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'Mismatch12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
@@ -81,9 +114,13 @@ describe('ActivateAccountPage', () => {
 
   it('validates password needs uppercase', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'nouppercase12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'nouppercase12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
@@ -95,10 +132,14 @@ describe('ActivateAccountPage', () => {
 
   it('calls activateAccount service with token and password', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     mockActivateAccount.mockResolvedValueOnce(undefined);
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'ValidPass12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
@@ -113,68 +154,161 @@ describe('ActivateAccountPage', () => {
 
   it('shows success message after activation', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     mockActivateAccount.mockResolvedValueOnce(undefined);
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'ValidPass12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/nalog uspešno aktiviran/i)).toBeInTheDocument();
+      expect(screen.getByText(/nalog uspesno aktiviran/i)).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: /idi na prijavu/i })).toBeInTheDocument();
   });
 
   it('navigates to login from success view', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     mockActivateAccount.mockResolvedValueOnce(undefined);
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'ValidPass12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/nalog uspešno aktiviran/i)).toBeInTheDocument();
+      expect(screen.getByText(/nalog uspesno aktiviran/i)).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole('button', { name: /idi na prijavu/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 
-  it('shows server error on failed activation', async () => {
-    mockSearchParams = new URLSearchParams('token=expired-token');
+  it('shows server error on failed activation when token is VALID at mount but BE rejects', async () => {
+    mockSearchParams = new URLSearchParams('token=valid-token');
+    mockValidToken();
     mockActivateAccount.mockRejectedValueOnce({
-      response: { data: { message: 'Token istekao' } },
+      response: { data: { message: 'Nesto je puklo' } },
     });
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'ValidPass12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Token istekao')).toBeInTheDocument();
+      expect(screen.getByText('Nesto je puklo')).toBeInTheDocument();
     });
   });
 
   it('shows loading state while submitting', async () => {
     mockSearchParams = new URLSearchParams('token=activation-token-abc');
+    mockValidToken();
     mockActivateAccount.mockImplementation(() => new Promise(() => {}));
     const user = userEvent.setup();
     renderWithProviders(<ActivateAccountPage />);
 
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nova lozinka/i)).toBeInTheDocument();
+    });
     await user.type(screen.getByLabelText(/nova lozinka/i), 'ValidPass12');
     await user.type(screen.getByLabelText(/potvrdite lozinku/i), 'ValidPass12');
     await user.click(screen.getByRole('button', { name: /aktiviraj nalog/i }));
 
     await waitFor(() => {
-      // "Aktivacija..." is the loading text on the submit button
       expect(screen.getByText('Aktivacija...')).toBeInTheDocument();
+    });
+  });
+
+  // Bug Sc 9 (12.05.2026) novi testovi: pre-check stanja tokena.
+
+  it('shows USED state when activation token already consumed', async () => {
+    mockSearchParams = new URLSearchParams('token=already-used-token');
+    mockGetTokenStatus.mockResolvedValueOnce({
+      status: 'USED',
+      expiresAt: '2026-05-13T20:00:00',
+      email: 'aktivirao@banka.rs',
+    });
+    renderWithProviders(<ActivateAccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-token-used')).toBeInTheDocument();
+    });
+    // Naslov "Link je vec iskoriscen" se pojavljuje u CardTitle; description
+    // takodje sadrzi "iskoriscen" pa koristimo getAllByText i proverimo >= 1.
+    expect(screen.getAllByText(/iskoriscen/i).length).toBeGreaterThan(0);
+    // Forma ne sme da postoji
+    expect(screen.queryByLabelText(/nova lozinka/i)).not.toBeInTheDocument();
+  });
+
+  it('shows EXPIRED state when activation token expired', async () => {
+    mockSearchParams = new URLSearchParams('token=expired-token');
+    mockGetTokenStatus.mockResolvedValueOnce({
+      status: 'EXPIRED',
+      expiresAt: '2026-05-01T20:00:00',
+      email: null,
+    });
+    renderWithProviders(<ActivateAccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-token-expired')).toBeInTheDocument();
+    });
+    expect(screen.getAllByText(/istekao/i).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText(/nova lozinka/i)).not.toBeInTheDocument();
+  });
+
+  it('shows ALREADY_ACTIVE state when account already activated', async () => {
+    mockSearchParams = new URLSearchParams('token=stale-token');
+    mockGetTokenStatus.mockResolvedValueOnce({
+      status: 'ALREADY_ACTIVE',
+      expiresAt: '2026-05-13T20:00:00',
+      email: 'aktivan@banka.rs',
+    });
+    renderWithProviders(<ActivateAccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-already-active')).toBeInTheDocument();
+    });
+    expect(screen.getAllByText(/aktivan|aktiviran/i).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText(/nova lozinka/i)).not.toBeInTheDocument();
+  });
+
+  it('shows INVALID state when BE returns INVALID', async () => {
+    mockSearchParams = new URLSearchParams('token=garbage-token');
+    mockGetTokenStatus.mockResolvedValueOnce({
+      status: 'INVALID',
+      expiresAt: null,
+      email: null,
+    });
+    renderWithProviders(<ActivateAccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-token-invalid')).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/nova lozinka/i)).not.toBeInTheDocument();
+  });
+
+  it('shows INVALID state when token status check throws', async () => {
+    mockSearchParams = new URLSearchParams('token=broken');
+    mockGetTokenStatus.mockRejectedValueOnce(new Error('network down'));
+    renderWithProviders(<ActivateAccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activation-token-invalid')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/ActivateAccount/ActivateAccountPage.tsx
+++ b/src/pages/ActivateAccount/ActivateAccountPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Eye, EyeOff, CheckCircle2, Loader2 } from 'lucide-react';
+import { Eye, EyeOff, CheckCircle2, Loader2, AlertTriangle, Clock, KeySquare } from 'lucide-react';
 import {
   activateAccountSchema,
   type ActivateAccountFormData,
@@ -12,11 +12,18 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/utils';
 import { getPasswordStrength, getStrengthInfo } from '../../utils/passwordStrength';
 import AuthPageLayout from '@/components/layout/AuthPageLayout';
+
+// Spec Sc 9 + ad-hoc bag 12.05.2026: pre renderovanja forme, FE poziva
+// GET /auth-employee/activation-token/{token}/status da bi proverio da li je
+// token jos validan. Bez ovog koraka, korisnik koji je vec aktivirao nalog
+// pa osvezi stranicu vidi formu (FE je propusta) iako BE-u poziv ne uspeva
+// (token je used). Token state se mapira u jedan od narednih ekrana.
+type TokenStatus = 'CHECKING' | 'VALID' | 'USED' | 'EXPIRED' | 'INVALID' | 'ALREADY_ACTIVE';
 
 export default function ActivateAccountPage() {
   const [searchParams] = useSearchParams();
@@ -27,6 +34,8 @@ export default function ActivateAccountPage() {
   const [serverError, setServerError] = useState('');
   const [success, setSuccess] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [tokenStatus, setTokenStatus] = useState<TokenStatus>('CHECKING');
+  const [tokenEmail, setTokenEmail] = useState<string | null>(null);
 
   const {
     register,
@@ -42,9 +51,34 @@ export default function ActivateAccountPage() {
   const strength = getPasswordStrength(passwordValue);
   const strengthInfo = getStrengthInfo(strength);
 
+  // Spec Sc 9 + Bug 12.05.2026: token state pre-check. Ako je token vec
+  // iskorisen ili istekao, ne renderujemo formu uopste — prikazujemo
+  // odgovarajucu poruku sa dugmetom za login (ALREADY_ACTIVE/USED) ili
+  // za kontakt admina (EXPIRED/INVALID).
+  useEffect(() => {
+    if (!token) {
+      setTokenStatus('INVALID');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await authService.getActivationTokenStatus(token);
+        if (cancelled) return;
+        setTokenStatus(result.status);
+        setTokenEmail(result.email ?? null);
+      } catch {
+        if (!cancelled) setTokenStatus('INVALID');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
   const onSubmit = async (data: ActivateAccountFormData) => {
     if (!token) {
-      setServerError('Nevažeći link za aktivaciju. Kontaktirajte administratora.');
+      setServerError('Nevazeci link za aktivaciju. Kontaktirajte administratora.');
       return;
     }
     setServerError('');
@@ -52,28 +86,53 @@ export default function ActivateAccountPage() {
     try {
       await authService.activateAccount({ token, password: data.password });
       setSuccess(true);
+      // Napomena: NE menjamo tokenStatus na USED ovde. Success state je
+      // distinkan UX — pokazuje "Nalog uspesno aktiviran" + "Idi na prijavu".
+      // Tek na sledeci mount (refresh stranice) pre-check ce detektovati
+      // USED status i prikazati "Vec iskoriscen" stranicu.
     } catch (err: unknown) {
       const error = err as { response?: { data?: { message?: string } } };
-      setServerError(
-        error.response?.data?.message ||
-          'Greška pri aktivaciji naloga. Link je možda istekao.'
-      );
+      const beMsg = error.response?.data?.message;
+      // Ako BE javi da je token iskorisen/istekao izmedju pre-checka i submita
+      // (race condition: drugi tab ili admin invalidacija), refresh-ujemo status
+      // da prikazemo pravu stranicu umesto generickog error toast-a.
+      if (beMsg && /vec used|already used|invalidated|expired/i.test(beMsg)) {
+        try {
+          const refreshed = await authService.getActivationTokenStatus(token);
+          setTokenStatus(refreshed.status);
+        } catch {
+          setTokenStatus('INVALID');
+        }
+        return;
+      }
+      setServerError(beMsg || 'Greska pri aktivaciji naloga. Link je mozda istekao.');
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  if (!token) {
+  // Spec Sc 9 — token istekao
+  if (tokenStatus === 'EXPIRED') {
     return (
       <AuthPageLayout>
         <div className="mx-auto max-w-[440px] animate-fade-up">
           <Card className="shadow-2xl shadow-indigo-500/5">
-            <CardContent className="p-6 text-center">
-              <Alert variant="destructive">
-                <AlertDescription>
-                  Nevažeći link za aktivaciju. Kontaktirajte vašeg administratora.
-                </AlertDescription>
-              </Alert>
+            <CardHeader className="text-center space-y-2">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/30">
+                <Clock className="h-7 w-7 text-amber-500" />
+              </div>
+              <CardTitle className="text-xl">Link za aktivaciju je istekao</CardTitle>
+              <CardDescription>
+                Aktivacioni link traje 24 sata. Vasa veza vise nije validna.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3" data-testid="activation-token-expired">
+              <p className="text-sm text-muted-foreground text-center">
+                Kontaktirajte vaseg administratora da vam posalje novi aktivacioni link.
+              </p>
+              <Button variant="outline" className="w-full" onClick={() => navigate('/login')}>
+                Nazad na prijavu
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -81,6 +140,92 @@ export default function ActivateAccountPage() {
     );
   }
 
+  // Spec Sc 9 + ad-hoc bag — token je vec iskorisen (najcesce: refresh stranice
+  // posle uspesne aktivacije, ili klik na isti email link drugi put).
+  if (tokenStatus === 'USED' || tokenStatus === 'ALREADY_ACTIVE') {
+    const isAlreadyActive = tokenStatus === 'ALREADY_ACTIVE';
+    return (
+      <AuthPageLayout>
+        <div className="mx-auto max-w-[440px] animate-fade-up">
+          <Card className="shadow-2xl shadow-indigo-500/5">
+            <CardHeader className="text-center space-y-2">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/10 ring-1 ring-emerald-500/30">
+                <CheckCircle2 className="h-7 w-7 text-emerald-500" />
+              </div>
+              <CardTitle className="text-xl">
+                {isAlreadyActive ? 'Nalog je vec aktivan' : 'Link je vec iskoriscen'}
+              </CardTitle>
+              <CardDescription>
+                {isAlreadyActive
+                  ? 'Vas nalog je vec aktiviran. Prijavite se sa email-om i lozinkom.'
+                  : 'Aktivacioni link je vec iskoriscen. Mozete se odmah prijaviti.'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3" data-testid={isAlreadyActive ? 'activation-already-active' : 'activation-token-used'}>
+              {tokenEmail && (
+                <Alert>
+                  <KeySquare className="h-4 w-4" />
+                  <AlertTitle>Email naloga</AlertTitle>
+                  <AlertDescription className="font-mono">{tokenEmail}</AlertDescription>
+                </Alert>
+              )}
+              <p className="text-sm text-muted-foreground text-center">
+                Ako ste zaboravili lozinku, koristite opciju "Zaboravili ste lozinku" na prijavi.
+              </p>
+              <Button
+                className="w-full bg-gradient-to-r from-indigo-500 to-violet-600 text-white font-semibold"
+                onClick={() => navigate('/login')}
+              >
+                Idi na prijavu
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </AuthPageLayout>
+    );
+  }
+
+  if (tokenStatus === 'INVALID' || !token) {
+    return (
+      <AuthPageLayout>
+        <div className="mx-auto max-w-[440px] animate-fade-up">
+          <Card className="shadow-2xl shadow-indigo-500/5">
+            <CardHeader className="text-center space-y-2">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-red-500/10 ring-1 ring-red-500/30">
+                <AlertTriangle className="h-7 w-7 text-red-500" />
+              </div>
+              <CardTitle className="text-xl">Nevazeci link za aktivaciju</CardTitle>
+              <CardDescription>
+                Aktivacioni token ne postoji u sistemu. Kontaktirajte administratora za novi link.
+              </CardDescription>
+            </CardHeader>
+            <CardContent data-testid="activation-token-invalid">
+              <Button variant="outline" className="w-full" onClick={() => navigate('/login')}>
+                Nazad na prijavu
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </AuthPageLayout>
+    );
+  }
+
+  if (tokenStatus === 'CHECKING') {
+    return (
+      <AuthPageLayout>
+        <div className="mx-auto max-w-[440px] animate-fade-up">
+          <Card className="shadow-2xl shadow-indigo-500/5">
+            <CardContent className="p-10 text-center">
+              <Loader2 className="mx-auto h-8 w-8 animate-spin text-muted-foreground" />
+              <p className="mt-3 text-sm text-muted-foreground">Provera linka za aktivaciju...</p>
+            </CardContent>
+          </Card>
+        </div>
+      </AuthPageLayout>
+    );
+  }
+
+  // tokenStatus === 'VALID' — renderujemo formu
   return (
     <AuthPageLayout>
       <div className="mx-auto w-full max-w-[480px] animate-fade-up">
@@ -98,9 +243,9 @@ export default function ActivateAccountPage() {
                 <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10 ring-1 ring-emerald-500/30">
                   <CheckCircle2 className="h-8 w-8 text-emerald-500" />
                 </div>
-                <h3 className="text-lg font-semibold">Nalog uspešno aktiviran!</h3>
+                <h3 className="text-lg font-semibold">Nalog uspesno aktiviran!</h3>
                 <p className="text-sm text-muted-foreground">
-                  Sada se možete prijaviti sa vašim email-om i lozinkom.
+                  Sada se mozete prijaviti sa vasim email-om i lozinkom.
                 </p>
                 <Button
                   className="w-full bg-gradient-to-r from-indigo-500 to-violet-600 text-white font-semibold"
@@ -115,6 +260,16 @@ export default function ActivateAccountPage() {
                   <Alert variant="destructive" className="mb-4">
                     <AlertDescription>{serverError}</AlertDescription>
                   </Alert>
+                )}
+
+                {tokenEmail && (
+                  <div className="mb-4 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 flex items-center gap-2">
+                    <KeySquare className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                    <p className="text-xs">
+                      <span className="text-muted-foreground">Aktivira se nalog: </span>
+                      <span className="font-mono font-semibold text-emerald-700 dark:text-emerald-300">{tokenEmail}</span>
+                    </p>
+                  </div>
                 )}
 
                 <div className="mb-4 rounded-lg border border-indigo-500/20 bg-indigo-500/5 p-3">
@@ -148,7 +303,7 @@ export default function ActivateAccountPage() {
                       <div className="space-y-1">
                         <Progress value={strength} className="h-1.5" indicatorClassName={strengthInfo.color} />
                         <p className="text-xs text-muted-foreground">
-                          Jačina lozinke: <span className="font-medium">{strengthInfo.label}</span>
+                          Jacina lozinke: <span className="font-medium">{strengthInfo.label}</span>
                         </p>
                       </div>
                     )}

--- a/src/pages/Actuary/ActuaryManagementPage.tsx
+++ b/src/pages/Actuary/ActuaryManagementPage.tsx
@@ -26,12 +26,18 @@ type FilterState = {
   email: string;
   firstName: string;
   lastName: string;
+  // Spec Celina 3 §69 (Bug T4-001 prijavljen 11.05.2026): "filtere po
+  // email-u, imenu, prezimenu i poziciji". Pozicija je nedostajala — sad
+  // dodajemo i sluzi za filtriranje po nazivu pozicije (Agent / Supervizor
+  // / specificno radno mesto ako se kasnije unese).
+  position: string;
 };
 
 const DEFAULT_FILTERS: FilterState = {
   email: '',
   firstName: '',
   lastName: '',
+  position: '',
 };
 
 function splitName(fullName: string): { firstName: string; lastName: string } {
@@ -76,13 +82,34 @@ export default function ActuaryManagementPage() {
         debouncedFilters.firstName || undefined,
         debouncedFilters.lastName || undefined
       );
-      setAgents(data);
+      // BE actuary endpoint trenutno filtrira po email/firstName/lastName;
+      // poziciju filtriramo na FE strani da Bug T4-001 odmah bude resen
+      // bez BE izmene. Pozicija agenta dolazi kroz `agent.actuaryType`
+      // (SUPERVISOR / AGENT) i/ili `agent.employeePosition` ako BE pruzi.
+      const positionQuery = debouncedFilters.position.trim().toLowerCase();
+      const filtered = positionQuery
+        ? data.filter((agent) => {
+            const positionLabel =
+              agent.actuaryType === 'SUPERVISOR' ? 'supervizor' : 'agent';
+            const empPosition = (
+              (agent as ActuaryInfo & { employeePosition?: string }).employeePosition ?? ''
+            ).toLowerCase();
+            return positionLabel.includes(positionQuery)
+                || empPosition.includes(positionQuery);
+          })
+        : data;
+      setAgents(filtered);
     } catch {
       setError('Greska pri ucitavanju aktuarnih podataka. Pokusajte ponovo.');
     } finally {
       setLoading(false);
     }
-  }, [debouncedFilters.email, debouncedFilters.firstName, debouncedFilters.lastName]);
+  }, [
+    debouncedFilters.email,
+    debouncedFilters.firstName,
+    debouncedFilters.lastName,
+    debouncedFilters.position,
+  ]);
 
   useEffect(() => {
     void loadAgents();
@@ -235,6 +262,18 @@ export default function ActuaryManagementPage() {
                 value={filters.lastName}
                 onChange={(e) => setFilters((current) => ({ ...current, lastName: e.target.value }))}
                 className="w-[230px] pl-9"
+              />
+            </div>
+            {/* Spec §69 (Bug T4-001): filter po poziciji (Agent / Supervizor /
+                tekstualni opis radnog mesta) */}
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Pretraga po poziciji"
+                value={filters.position}
+                onChange={(e) => setFilters((current) => ({ ...current, position: e.target.value }))}
+                className="w-[230px] pl-9"
+                data-testid="actuary-filter-position"
               />
             </div>
             <Button variant="ghost" onClick={() => setFilters(DEFAULT_FILTERS)}>

--- a/src/pages/Admin/EmployeeEditPage.test.tsx
+++ b/src/pages/Admin/EmployeeEditPage.test.tsx
@@ -101,7 +101,11 @@ describe('EmployeeEditPage', () => {
     // Check that form fields have the correct values
     expect(screen.getByLabelText(/^ime$/i)).toHaveValue('Marko');
     expect(screen.getByLabelText(/^prezime$/i)).toHaveValue('Petrovic');
-    expect(screen.getByLabelText(/^email$/i)).toHaveValue('marko.petrovic@banka.rs');
+    // Bug T1-009 fix (12.05.2026): label sad sadrzi "(ne moze se menjati)" pa
+    // koristimo broader regex koji match-uje pocetak label-a.
+    expect(screen.getByLabelText(/^email/i)).toHaveValue('marko.petrovic@banka.rs');
+    expect(screen.getByLabelText(/^email/i)).toBeDisabled();
+    expect(screen.getByTestId('employee-edit-email-disabled')).toBeInTheDocument();
     expect(screen.getByLabelText(/^broj telefona$/i)).toHaveValue('+381 60 1234567');
     expect(screen.getByLabelText(/^adresa$/i)).toHaveValue('Bulevar Mihajla Pupina 10, Beograd');
 

--- a/src/pages/Admin/EmployeeEditPage.tsx
+++ b/src/pages/Admin/EmployeeEditPage.tsx
@@ -397,10 +397,28 @@ export default function EmployeeEditPage() {
               <CardContent>
                 <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
+                    <Label htmlFor="email">
+                      Email <span className="text-xs text-muted-foreground font-normal">(ne moze se menjati)</span>
+                    </Label>
                     <div className="relative">
                       <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                      <Input id="email" type="email" className="h-11 pl-9" {...register('email')} />
+                      {/*
+                       * Spec §30 dozvoljava izmenu "svih osim ID-a i passworda" ali Plan
+                       * Manuelnog Testiranja + Bug T1-009/T1-010 (prijavljen 12.05.2026)
+                       * traze read-only ponasanje. Email je identitet zaposlenog (login key,
+                       * email links, audit log) i ne sme se menjati bez admin procedure.
+                       * BE EmployeeService.updateEmployee dodatno odbija email change (defense
+                       * in depth ako neko zaobide disabled FE polje preko DevTools-a).
+                       */}
+                      <Input
+                        id="email"
+                        type="email"
+                        className="h-11 pl-9 bg-muted/40 cursor-not-allowed"
+                        {...register('email')}
+                        disabled
+                        aria-readonly
+                        data-testid="employee-edit-email-disabled"
+                      />
                     </div>
                     {errors.email && (
                       <p className="text-sm text-destructive">{errors.email.message}</p>

--- a/src/pages/Admin/EmployeeListPage.tsx
+++ b/src/pages/Admin/EmployeeListPage.tsx
@@ -10,16 +10,21 @@ import {
   ChevronRight,
   UserCheck,
   UserX,
+  PowerOff,
+  Power,
+  Loader2,
 } from 'lucide-react';
 import type { Employee, EmployeeFilters } from '../../types';
 import { Permission } from '../../types';
 import { employeeService } from '../../services/employeeService';
 import { useAuth } from '../../context/AuthContext';
+import { toast } from '@/lib/notify';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import * as Dialog from '@radix-ui/react-dialog';
 import {
   Table,
   TableBody,
@@ -72,6 +77,15 @@ export default function EmployeeListPage() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [totalElements, setTotalElements] = useState(0);
+  // Spec Sc 14 (Bug T1-011 prijavljen 12.05.2026): "Pored zeljenog zaposlenog
+  // klik na 'Deaktiviraj' (ikona X ili switch)". Pre fix-a, deaktivacija je
+  // bila dostupna SAMO unutar edit forme preko isActive switch-a. Sad dodajemo
+  // row-level dugme u koloni Akcije sa confirm dialog-om.
+  const [confirmAction, setConfirmAction] = useState<{
+    employee: Employee;
+    nextActive: boolean;
+  } | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
 
   const fetchEmployees = useCallback(async () => {
     setLoading(true);
@@ -112,6 +126,46 @@ export default function EmployeeListPage() {
   const handleRowClick = (employee: Employee) => {
     if (canEdit(employee)) {
       navigate(`/admin/employees/${employee.id}`);
+    }
+  };
+
+  /**
+   * Spec Sc 14: deaktivacija sa liste. Otvara confirm dialog pre BE poziva
+   * jer je promena destruktivna (deaktiviran zaposleni ne moze da se uloguje).
+   * Ako se zaposleni reaktivira, isti flow (Power umesto PowerOff ikone).
+   */
+  const handleConfirmAction = async () => {
+    if (!confirmAction) return;
+    const { employee, nextActive } = confirmAction;
+    setActionLoading(true);
+    try {
+      if (nextActive) {
+        // Reaktivacija — koristimo update sa { isActive: true }
+        await employeeService.update(employee.id, {
+          firstName: employee.firstName,
+          lastName: employee.lastName,
+          dateOfBirth: employee.dateOfBirth,
+          gender: employee.gender,
+          phoneNumber: employee.phoneNumber,
+          address: employee.address,
+          position: employee.position,
+          department: employee.department,
+          isActive: true,
+          permissions: employee.permissions,
+        });
+        toast.success(`Zaposleni ${employee.firstName} ${employee.lastName} je reaktiviran.`);
+      } else {
+        await employeeService.deactivate(employee.id);
+        toast.success(`Zaposleni ${employee.firstName} ${employee.lastName} je deaktiviran.`);
+      }
+      setConfirmAction(null);
+      await fetchEmployees();
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message
+        ?? 'Operacija nije uspela. Pokusajte ponovo.';
+      toast.error(msg);
+    } finally {
+      setActionLoading(false);
     }
   };
 
@@ -252,7 +306,7 @@ export default function EmployeeListPage() {
                 <TableHead>Telefon</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Uloga</TableHead>
-                <TableHead className="text-center w-16">Akcije</TableHead>
+                <TableHead className="text-center w-28">Akcije</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -265,7 +319,7 @@ export default function EmployeeListPage() {
                   <TableCell><div className="h-4 w-24 animate-pulse rounded bg-muted" /></TableCell>
                   <TableCell><div className="h-4 w-4 rounded-full bg-muted animate-pulse" /></TableCell>
                   <TableCell><div className="h-4 w-20 animate-pulse rounded bg-muted" /></TableCell>
-                  <TableCell className="text-center"><div className="mx-auto h-8 w-8 rounded-lg bg-muted animate-pulse" /></TableCell>
+                  <TableCell className="text-center"><div className="mx-auto h-8 w-16 rounded-lg bg-muted animate-pulse" /></TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -283,7 +337,7 @@ export default function EmployeeListPage() {
                 <TableHead>Telefon</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Uloga</TableHead>
-                <TableHead className="text-center w-16">Akcije</TableHead>
+                <TableHead className="text-center w-28">Akcije</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -342,18 +396,43 @@ export default function EmployeeListPage() {
                     </TableCell>
                     <TableCell className="text-center">
                       {canEdit(emp) && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8 rounded-lg hover:bg-indigo-500/10 hover:text-indigo-600 transition-all"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            navigate(`/admin/employees/${emp.id}`);
-                          }}
-                          title="Izmeni zaposlenog"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
+                        <div className="flex items-center justify-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 rounded-lg hover:bg-indigo-500/10 hover:text-indigo-600 transition-all"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              navigate(`/admin/employees/${emp.id}`);
+                            }}
+                            title="Izmeni zaposlenog"
+                            data-testid={`employee-edit-btn-${emp.id}`}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          {/*
+                           * Spec Sc 14 (Bug T1-011): row-level dugme "Deaktiviraj"
+                           * (ili "Aktiviraj" ako je vec neaktivan). Klik otvara confirm
+                           * dialog — destruktivna operacija mora biti potvrdena.
+                           */}
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={`h-8 w-8 rounded-lg transition-all ${
+                              emp.isActive
+                                ? 'hover:bg-red-500/10 hover:text-red-600'
+                                : 'hover:bg-emerald-500/10 hover:text-emerald-600'
+                            }`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setConfirmAction({ employee: emp, nextActive: !emp.isActive });
+                            }}
+                            title={emp.isActive ? 'Deaktiviraj zaposlenog' : 'Reaktiviraj zaposlenog'}
+                            data-testid={`employee-toggle-active-btn-${emp.id}`}
+                          >
+                            {emp.isActive ? <PowerOff className="h-4 w-4" /> : <Power className="h-4 w-4" />}
+                          </Button>
+                        </div>
                       )}
                     </TableCell>
                   </TableRow>
@@ -412,6 +491,81 @@ export default function EmployeeListPage() {
         </Card>
       )}
 
+      {/* Confirm dialog za deaktivaciju/reaktivaciju (Bug T1-011 fix) */}
+      <Dialog.Root
+        open={confirmAction !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !actionLoading) setConfirmAction(null);
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+          <Dialog.Content
+            className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-background shadow-2xl"
+            data-testid="employee-toggle-active-dialog"
+          >
+            {confirmAction && (
+              <>
+                <div className="flex items-start gap-3 border-b p-6">
+                  <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${
+                    confirmAction.nextActive
+                      ? 'bg-emerald-100 dark:bg-emerald-950/40'
+                      : 'bg-red-100 dark:bg-red-950/40'
+                  }`}>
+                    {confirmAction.nextActive ? (
+                      <Power className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                    ) : (
+                      <PowerOff className="h-5 w-5 text-red-600 dark:text-red-400" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <Dialog.Title className="text-lg font-semibold">
+                      {confirmAction.nextActive ? 'Reaktivacija zaposlenog' : 'Deaktivacija zaposlenog'}
+                    </Dialog.Title>
+                    <Dialog.Description className="mt-1 text-sm text-muted-foreground">
+                      {confirmAction.nextActive
+                        ? `Da li ste sigurni da zelite da reaktivirate ${confirmAction.employee.firstName} ${confirmAction.employee.lastName}? Nakon reaktivacije zaposleni ce moci ponovo da se uloguje.`
+                        : `Da li ste sigurni da zelite da deaktivirate ${confirmAction.employee.firstName} ${confirmAction.employee.lastName}? Deaktivirani zaposleni ne moze da se uloguje na sistem.`}
+                    </Dialog.Description>
+                  </div>
+                </div>
+                <div className="flex justify-end gap-2 p-6">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setConfirmAction(null)}
+                    disabled={actionLoading}
+                  >
+                    Otkazi
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={handleConfirmAction}
+                    disabled={actionLoading}
+                    className={
+                      confirmAction.nextActive
+                        ? 'bg-gradient-to-r from-emerald-500 to-green-600 text-white font-semibold'
+                        : 'bg-gradient-to-r from-red-500 to-rose-600 text-white font-semibold'
+                    }
+                    data-testid="employee-toggle-active-confirm"
+                  >
+                    {actionLoading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Cuvanje...
+                      </>
+                    ) : confirmAction.nextActive ? (
+                      'Reaktiviraj'
+                    ) : (
+                      'Deaktiviraj'
+                    )}
+                  </Button>
+                </div>
+              </>
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
 }

--- a/src/pages/Employee/CreateAccountPage.tsx
+++ b/src/pages/Employee/CreateAccountPage.tsx
@@ -1,12 +1,17 @@
 //
 // Ova stranica je dostupna samo zaposlenima (employee/admin).
 // Omogucava kreiranje novog bankovnog racuna za klijenta.
+//
+// Spec Celina 2 §41-42 + Bug T2-001/T2-002/T2-003 (prijavljen 12.05.2026):
+// Tip vlasnistva (Licni/Poslovni) i Tip racuna (Tekuci/Devizni) su DVA
+// ORTOGONALNA KONCEPTA — moraju biti odvojeni dropdown-i. Plus mora postojati
+// polje za Dnevni/Mesecni limit (Celina 2 §454-455).
 
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft, Plus, Loader2, User, Building2, CreditCard, Wallet, Eye } from 'lucide-react';
+import { ArrowLeft, Plus, Loader2, User, Building2, CreditCard, Wallet, Eye, Gauge } from 'lucide-react';
 import { toast } from '@/lib/notify';
 import { accountService } from '@/services/accountService';
 import { clientService } from '@/services/clientService';
@@ -31,15 +36,18 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-const accountTypeLabels: Record<string, string> = {
-  TEKUCI: 'Tekuci racun',
-  DEVIZNI: 'Devizni racun',
+const ownershipTypeLabels: Record<string, string> = {
+  LICNI: 'Licni racun',
   POSLOVNI: 'Poslovni racun',
 };
 
-const accountTypeColors: Record<string, string> = {
-  TEKUCI: 'from-blue-500 to-blue-700',
-  DEVIZNI: 'from-emerald-500 to-green-700',
+const accountTypeLabels: Record<string, string> = {
+  TEKUCI: 'Tekuci racun',
+  DEVIZNI: 'Devizni racun',
+};
+
+const ownershipColors: Record<string, string> = {
+  LICNI: 'from-indigo-500 to-violet-700',
   POSLOVNI: 'from-amber-500 to-orange-700',
 };
 
@@ -59,10 +67,14 @@ export default function CreateAccountPage() {
     resolver: zodResolver(createAccountSchema),
     defaultValues: {
       ownerEmail: '',
+      ownershipType: 'LICNI',
       accountType: 'TEKUCI',
       accountSubtype: 'STANDARDNI',
       currency: 'RSD',
       initialDeposit: undefined,
+      // Spec Celina 2 §454-455: defaultni limiti.
+      dailyLimit: 250000,
+      monthlyLimit: 1000000,
       createCard: false,
       companyName: '',
       registrationNumber: '',
@@ -74,16 +86,19 @@ export default function CreateAccountPage() {
     },
   });
 
+  const ownershipType = watch('ownershipType');
   const accountType = watch('accountType');
   const ownerEmail = watch('ownerEmail');
   const createCard = watch('createCard');
   const currency = watch('currency');
   const initialDeposit = watch('initialDeposit');
   const accountSubtype = watch('accountSubtype');
+  const dailyLimit = watch('dailyLimit');
+  const monthlyLimit = watch('monthlyLimit');
   const companyName = watch('companyName');
 
   const subtypeOptions = useMemo(() => {
-    if (accountType === 'POSLOVNI') {
+    if (ownershipType === 'POSLOVNI') {
       return [
         { value: 'DOO', label: 'DOO' },
         { value: 'AD', label: 'AD' },
@@ -99,29 +114,36 @@ export default function CreateAccountPage() {
       { value: 'STUDENTSKI', label: 'Studentski' },
       { value: 'ZA_NEZAPOSLENE', label: 'Za nezaposlene' },
     ];
-  }, [accountType]);
+  }, [ownershipType]);
 
   const currencyOptions = useMemo(() => {
+    // Tekuci moze biti samo RSD (spec Celina 2 §43).
     if (accountType === 'TEKUCI') return ['RSD'];
-    if (accountType === 'DEVIZNI') return ['EUR', 'CHF', 'USD', 'GBP', 'JPY', 'CAD', 'AUD'];
-    return ['RSD', 'EUR', 'CHF', 'USD', 'GBP', 'JPY', 'CAD', 'AUD'];
+    // Devizni — samo strane valute (spec §47).
+    return ['EUR', 'CHF', 'USD', 'GBP', 'JPY', 'CAD', 'AUD'];
   }, [accountType]);
 
+  // Kad se promeni ownershipType, resetuj subtype na prvu validnu opciju.
+  useEffect(() => {
+    if (ownershipType === 'POSLOVNI') {
+      if (!['DOO', 'AD', 'FONDACIJA'].includes(accountSubtype || '')) {
+        setValue('accountSubtype', 'DOO');
+      }
+    } else {
+      if (['DOO', 'AD', 'FONDACIJA'].includes(accountSubtype || '')) {
+        setValue('accountSubtype', 'STANDARDNI');
+      }
+    }
+  }, [ownershipType, accountSubtype, setValue]);
+
+  // Kad se promeni accountType, resetuj currency na prvu validnu opciju.
   useEffect(() => {
     if (accountType === 'TEKUCI') {
       setValue('currency', 'RSD');
-      setValue('accountSubtype', 'STANDARDNI');
-      return;
-    }
-    if (accountType === 'DEVIZNI') {
+    } else if (accountType === 'DEVIZNI' && currency === 'RSD') {
       setValue('currency', 'EUR');
-      setValue('accountSubtype', 'STANDARDNI');
-      return;
     }
-
-    setValue('currency', 'RSD');
-    setValue('accountSubtype', 'DOO');
-  }, [accountType, setValue]);
+  }, [accountType, currency, setValue]);
 
   useEffect(() => {
     const query = ownerEmail?.trim() || '';
@@ -145,9 +167,17 @@ export default function CreateAccountPage() {
     return () => window.clearTimeout(timeoutId);
   }, [ownerEmail]);
 
-  const mapAccountType = (feType: string): string => {
-    const map: Record<string, string> = { TEKUCI: 'CHECKING', DEVIZNI: 'FOREIGN', POSLOVNI: 'BUSINESS' };
-    return map[feType] || feType;
+  /**
+   * BE accountType ima 3 vrednosti (CHECKING, FOREIGN, BUSINESS) — mapiramo
+   * iz nase ortogonalne (ownershipType, accountType) kombinacije:
+   *   LICNI + TEKUCI → CHECKING (RSD)
+   *   LICNI + DEVIZNI → FOREIGN (foreign currency)
+   *   POSLOVNI + bilo koji → BUSINESS (currency razlikuje tekuci vs devizni)
+   * BE razlikuje poslovni tekuci od poslovnog deviznog kroz currency polje.
+   */
+  const resolveBeAccountType = (ownership: string, type: string): string => {
+    if (ownership === 'POSLOVNI') return 'BUSINESS';
+    return type === 'TEKUCI' ? 'CHECKING' : 'FOREIGN';
   };
 
   const mapAccountSubtype = (feSub: string): string => {
@@ -162,20 +192,25 @@ export default function CreateAccountPage() {
   const onSubmit = async (data: CreateAccountFormData) => {
     setIsSubmitting(true);
     try {
-      const isBusiness = data.accountType === 'POSLOVNI';
+      const isBusiness = data.ownershipType === 'POSLOVNI';
+      const beAccountType = resolveBeAccountType(data.ownershipType, data.accountType);
       await accountService.create({
         ownerEmail: data.ownerEmail,
-        accountType: mapAccountType(data.accountType) as AccountType,
+        accountType: beAccountType as AccountType,
         accountSubtype: mapAccountSubtype(data.accountSubtype || 'STANDARDNI') as AccountSubtype,
         currency: data.currency as Currency,
         initialDeposit: data.initialDeposit,
+        // BE prima dailyLimit/monthlyLimit i koristi ih kao initial values.
+        // Ako su undefined, BE primenjuje default-e (250k / 1M).
+        dailyLimit: data.dailyLimit,
+        monthlyLimit: data.monthlyLimit,
         createCard: data.createCard,
         companyName: isBusiness ? data.companyName : undefined,
         registrationNumber: isBusiness ? data.registrationNumber : undefined,
         taxId: isBusiness ? data.taxId : undefined,
         activityCode: isBusiness ? data.activityCode : undefined,
         firmAddress: isBusiness ? [data.firmAddress, data.firmCity, data.firmCountry].filter(Boolean).join(', ') : undefined,
-      });
+      } as Parameters<typeof accountService.create>[0]);
 
       toast.success('Racun uspesno kreiran.');
       navigate('/employee/accounts');
@@ -259,23 +294,43 @@ export default function CreateAccountPage() {
               </CardHeader>
               <CardContent className="space-y-5">
                 <div className="grid gap-5 md:grid-cols-2">
+                  {/* Spec §41-42: ortogonalna dva polja — vlasnistvo i tehnicki tip */}
+                  <div className="space-y-2">
+                    <Label>Tip vlasnistva *</Label>
+                    <Select
+                      value={ownershipType}
+                      onValueChange={(val) => setValue('ownershipType', val as 'LICNI' | 'POSLOVNI', { shouldValidate: true })}
+                    >
+                      <SelectTrigger className="h-11" data-testid="account-ownership-trigger">
+                        <SelectValue placeholder="Izaberite tip vlasnistva" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="LICNI" data-testid="account-ownership-licni">Licni</SelectItem>
+                        <SelectItem value="POSLOVNI" data-testid="account-ownership-poslovni">Poslovni</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {errors.ownershipType && <p className="text-sm font-medium text-destructive">{errors.ownershipType.message}</p>}
+                  </div>
+
                   <div className="space-y-2">
                     <Label>Tip racuna *</Label>
                     <Select
                       value={accountType}
-                      onValueChange={(val) => setValue('accountType', val as 'TEKUCI' | 'DEVIZNI' | 'POSLOVNI', { shouldValidate: true })}
+                      onValueChange={(val) => setValue('accountType', val as 'TEKUCI' | 'DEVIZNI', { shouldValidate: true })}
                     >
-                      <SelectTrigger className="h-11">
-                        <SelectValue placeholder="Izaberite tip" />
+                      <SelectTrigger className="h-11" data-testid="account-type-trigger">
+                        <SelectValue placeholder="Izaberite tip racuna" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="TEKUCI">Tekuci</SelectItem>
-                        <SelectItem value="DEVIZNI">Devizni</SelectItem>
-                        <SelectItem value="POSLOVNI">Poslovni</SelectItem>
+                        <SelectItem value="TEKUCI" data-testid="account-type-tekuci">Tekuci (RSD)</SelectItem>
+                        <SelectItem value="DEVIZNI" data-testid="account-type-devizni">Devizni</SelectItem>
                       </SelectContent>
                     </Select>
+                    {errors.accountType && <p className="text-sm font-medium text-destructive">{errors.accountType.message}</p>}
                   </div>
+                </div>
 
+                <div className="grid gap-5 md:grid-cols-2">
                   <div className="space-y-2">
                     <Label>Podvrsta racuna *</Label>
                     <Select
@@ -295,9 +350,7 @@ export default function CreateAccountPage() {
                     </Select>
                     {errors.accountSubtype && <p className="text-sm font-medium text-destructive">{errors.accountSubtype.message}</p>}
                   </div>
-                </div>
 
-                <div className="grid gap-5 md:grid-cols-2">
                   <div className="space-y-2">
                     <Label>Valuta *</Label>
                     <Select
@@ -318,21 +371,21 @@ export default function CreateAccountPage() {
                     </Select>
                     {errors.currency && <p className="text-sm font-medium text-destructive">{errors.currency.message}</p>}
                   </div>
+                </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="initialDeposit">Inicijalni depozit</Label>
-                    <Input
-                      id="initialDeposit"
-                      type="number"
-                      step="0.01"
-                      placeholder="0.00"
-                      className="h-11 font-mono"
-                      {...register('initialDeposit', {
-                        setValueAs: (value) => (value === '' ? undefined : Number(value)),
-                      })}
-                    />
-                    {errors.initialDeposit && <p className="text-sm font-medium text-destructive">{errors.initialDeposit.message}</p>}
-                  </div>
+                <div className="space-y-2">
+                  <Label htmlFor="initialDeposit">Inicijalni depozit</Label>
+                  <Input
+                    id="initialDeposit"
+                    type="number"
+                    step="0.01"
+                    placeholder="0.00"
+                    className="h-11 font-mono"
+                    {...register('initialDeposit', {
+                      setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                    })}
+                  />
+                  {errors.initialDeposit && <p className="text-sm font-medium text-destructive">{errors.initialDeposit.message}</p>}
                 </div>
 
                 <div className="flex items-center gap-3 rounded-xl border p-4 bg-muted/30 transition-colors hover:bg-muted/50">
@@ -350,8 +403,56 @@ export default function CreateAccountPage() {
               </CardContent>
             </Card>
 
+            {/* Limits section — Bug T2-003 (Plan_Manuelnog_Testiranja zahteva) */}
+            <Card className="rounded-2xl shadow-sm border-l-4 border-l-blue-500">
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <div className="h-5 w-1 rounded-full bg-gradient-to-b from-blue-500 to-indigo-600" />
+                  <Gauge className="h-4 w-4 text-blue-500" />
+                  <CardTitle>Limiti transakcija</CardTitle>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Maksimalni iznos transakcija po danu/mesecu. Default: 250.000 / 1.000.000 ({currency || 'RSD'}).
+                </p>
+              </CardHeader>
+              <CardContent>
+                <div className="grid gap-5 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="dailyLimit">Dnevni limit</Label>
+                    <Input
+                      id="dailyLimit"
+                      type="number"
+                      step="0.01"
+                      placeholder="250000"
+                      className="h-11 font-mono"
+                      data-testid="account-daily-limit"
+                      {...register('dailyLimit', {
+                        setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                      })}
+                    />
+                    {errors.dailyLimit && <p className="text-sm font-medium text-destructive">{errors.dailyLimit.message}</p>}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="monthlyLimit">Mesecni limit</Label>
+                    <Input
+                      id="monthlyLimit"
+                      type="number"
+                      step="0.01"
+                      placeholder="1000000"
+                      className="h-11 font-mono"
+                      data-testid="account-monthly-limit"
+                      {...register('monthlyLimit', {
+                        setValueAs: (value) => (value === '' ? undefined : Number(value)),
+                      })}
+                    />
+                    {errors.monthlyLimit && <p className="text-sm font-medium text-destructive">{errors.monthlyLimit.message}</p>}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
             {/* Business fields */}
-            {accountType === 'POSLOVNI' && (
+            {ownershipType === 'POSLOVNI' && (
               <Card className="rounded-2xl shadow-sm border-l-4 border-l-amber-500">
                 <CardHeader>
                   <div className="flex items-center gap-2">
@@ -447,14 +548,16 @@ export default function CreateAccountPage() {
               </CardHeader>
               <CardContent className="space-y-4">
                 {/* Mini card preview */}
-                <div className={`relative rounded-2xl bg-gradient-to-br ${accountTypeColors[accountType] || 'from-indigo-500 to-violet-700'} p-5 text-white shadow-lg overflow-hidden`}>
+                <div className={`relative rounded-2xl bg-gradient-to-br ${ownershipColors[ownershipType] || 'from-indigo-500 to-violet-700'} p-5 text-white shadow-lg overflow-hidden`}>
                   <div className="absolute inset-0 opacity-10">
                     <div className="absolute -right-8 -top-8 h-32 w-32 rounded-full bg-white/20" />
                     <div className="absolute -left-4 -bottom-4 h-24 w-24 rounded-full bg-white/10" />
                   </div>
                   <div className="relative space-y-3">
                     <div className="flex items-center justify-between">
-                      <p className="text-xs font-medium text-white/70">{accountTypeLabels[accountType] || 'Racun'}</p>
+                      <p className="text-xs font-medium text-white/70">
+                        {ownershipTypeLabels[ownershipType] || 'Racun'} · {accountTypeLabels[accountType]?.replace(' racun', '') || ''}
+                      </p>
                       <Wallet className="h-5 w-5 text-white/50" />
                     </div>
                     <p className="text-2xl font-bold font-mono tabular-nums">
@@ -475,6 +578,10 @@ export default function CreateAccountPage() {
                 {/* Details list */}
                 <div className="space-y-3">
                   <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Vlasnistvo</span>
+                    <Badge variant="secondary" className="font-medium">{ownershipTypeLabels[ownershipType] || ownershipType}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
                     <span className="text-muted-foreground">Tip</span>
                     <Badge variant="secondary" className="font-medium">{accountTypeLabels[accountType] || accountType}</Badge>
                   </div>
@@ -493,13 +600,25 @@ export default function CreateAccountPage() {
                     </span>
                   </div>
                   <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Dnevni limit</span>
+                    <span className="font-mono font-medium">
+                      {dailyLimit != null ? Number(dailyLimit).toLocaleString('sr-RS') : '-'}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Mesecni limit</span>
+                    <span className="font-mono font-medium">
+                      {monthlyLimit != null ? Number(monthlyLimit).toLocaleString('sr-RS') : '-'}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
                     <span className="text-muted-foreground">Kartica</span>
                     <div className={`flex items-center gap-1.5 ${createCard ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`}>
                       <CreditCard className="h-3.5 w-3.5" />
                       <span className="font-medium">{createCard ? 'Da' : 'Ne'}</span>
                     </div>
                   </div>
-                  {accountType === 'POSLOVNI' && companyName && (
+                  {ownershipType === 'POSLOVNI' && companyName && (
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-muted-foreground">Firma</span>
                       <span className="font-medium truncate max-w-[150px]">{companyName}</span>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -17,6 +17,8 @@ import portfolioService from '@/services/portfolioService';
 import orderService from '@/services/orderService';
 import type { PortfolioSummary, Order } from '@/types/celina3';
 import type { Account, ExchangeRate, Transaction, PaymentRecipient } from '@/types/celina2';
+import { savingsService } from '@/services/savingsService';
+import type { SavingsDepositDto } from '@/types/savings';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -242,6 +244,7 @@ export default function HomePage() {
   const [portfolioSummary, setPortfolioSummary] = useState<PortfolioSummary | null>(null);
   const [recentOrders, setRecentOrders] = useState<Order[]>([]);
   const [employeeLoading, setEmployeeLoading] = useState(true);
+  const [deposits, setDeposits] = useState<SavingsDepositDto[]>([]);
 
   useEffect(() => {
     const load = async () => {
@@ -265,6 +268,15 @@ export default function HomePage() {
     };
     load();
   }, []);
+
+  // Load savings deposits for client dashboard KPI chip
+  useEffect(() => {
+    if (user?.role === 'CLIENT') {
+      savingsService.listMyDeposits()
+        .then(setDeposits)
+        .catch(() => setDeposits([]));
+    }
+  }, [user?.role]);
 
   // Load portfolio + orders for employee dashboard
   useEffect(() => {
@@ -350,6 +362,24 @@ export default function HomePage() {
       totalTxCount: transactions.length,
     };
   }, [transactions, accounts]);
+
+  // Total savings in RSD (active deposits converted via exchange rates)
+  const totalSavingsRsd = useMemo(() => {
+    const rateMap = new Map<string, number>();
+    exchangeRates.forEach(r => {
+      const rsdPerUnit = r.middleRate && r.middleRate > 0 ? (1 / r.middleRate) : 0;
+      if (rsdPerUnit > 0) rateMap.set(r.currency, rsdPerUnit);
+    });
+    return deposits
+      .filter(d => d.status === 'ACTIVE')
+      .reduce((sum, d) => {
+        const rate = d.currencyCode === 'RSD' ? 1 : (rateMap.get(d.currencyCode) ?? 0);
+        return sum + d.principalAmount * rate;
+      }, 0);
+  }, [deposits, exchangeRates]);
+
+  const activeDepositCount = useMemo(() =>
+    deposits.filter(d => d.status === 'ACTIVE').length, [deposits]);
 
   // Chart data (memoized to avoid regenerating random data on every render)
   const balanceHistory = useMemo(() => generateBalanceHistory(totalRSD || 250000, chartPeriod), [totalRSD, chartPeriod]);
@@ -491,6 +521,17 @@ export default function HomePage() {
                   {monthlyStats.savings >= 0 ? 'Ustedjeno ' : 'Manjak '}
                   {formatAmount(Math.abs(monthlyStats.savings), 0)}
                 </div>
+              </div>
+
+              <div className="col-span-2 rounded-2xl bg-sky-400/15 backdrop-blur-sm px-4 py-3 border border-sky-300/20">
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-sky-100">Orocno</span>
+                  <PiggyBank className="h-3.5 w-3.5 text-sky-200" />
+                </div>
+                <div className="mt-1 text-xl font-bold font-mono tabular-nums text-sky-100">
+                  {balanceVisible ? formatAmount(totalSavingsRsd, 0) : '•••••'}
+                </div>
+                <div className="text-[10px] text-sky-200/80">RSD · {activeDepositCount} aktivnih</div>
               </div>
             </div>
           </div>

--- a/src/pages/Login/LoginPage.test.tsx
+++ b/src/pages/Login/LoginPage.test.tsx
@@ -143,7 +143,10 @@ describe('LoginPage', () => {
     await user.click(screen.getByRole('button', { name: /prijavi se/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/pogrešan email ili lozinka/i)).toBeInTheDocument();
+      // Posle Bug T1-013 fix-a (12.05.2026) poruka je preformulisana: pre je
+      // bila "Pogrešan email ili lozinka", sad "Neispravan email ili lozinka."
+      // (uskladjeno sa BE porukom koja je takodje SR).
+      expect(screen.getByText(/neispravan email ili lozinka/i)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -13,10 +13,15 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import AuthPageLayout from '@/components/layout/AuthPageLayout';
 
 // Opc.2 — Account lockout: BE AccountLockoutService zakljuca email posle 5
-// neuspesnih pokusaja na 15 min. BE poruka pocinje sa "Account temporarily
-// locked" — FE detektuje tu prefix-iranu poruku i prikazuje specifican
-// crveni alert sa Lock ikonicom (umesto generickog "Pogrešan email").
-const LOCKOUT_PREFIX = 'Account temporarily locked';
+// neuspesnih pokusaja na 15 min. BE poruka pocinje sa "Nalog je privremeno
+// zakljucan" (SR — pre 12.05.2026 bila je engleska, Bug T1-017). FE detektuje
+// tu prefix-iranu poruku i prikazuje specifican amber alert sa Lock ikonicom
+// (umesto generickog "Pogresan email").
+const LOCKOUT_PREFIXES = ['Nalog je privremeno zakljucan', 'Account temporarily locked'];
+
+function isLockoutMessage(msg: string): boolean {
+  return LOCKOUT_PREFIXES.some((prefix) => msg.startsWith(prefix));
+}
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -30,6 +35,7 @@ export default function LoginPage() {
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors },
   } = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -45,15 +51,21 @@ export default function LoginPage() {
       navigate('/home');
     } catch (err: unknown) {
       const error = err as { response?: { data?: { message?: string } }; message?: string };
-      // Opc.2 — BE AccountLockoutService.AccountLockedException puca sa porukom
-      // pocinjucom "Account temporarily locked due to too many failed attempts;
-      // try again in N min". FE detektuje ovaj prefix i prikazuje lockout alert.
       const beMessage = error.response?.data?.message ?? error.message ?? '';
-      if (beMessage.startsWith(LOCKOUT_PREFIX)) {
+      // Spec Sc 2 (Bug T1-013 prijavljen 12.05.2026): polje "Lozinka" se mora
+      // ocistiti posle neuspesnog login-a. Email ostavljamo da korisnik ne mora
+      // ponovo da kuca. setValue iz react-hook-form-a triggeruje re-render +
+      // ocisti DOM input value.
+      setValue('password', '', { shouldValidate: false, shouldDirty: false });
+      // Opc.2 — BE AccountLockoutService.AccountLockedException puca sa porukom
+      // koja pocinje "Nalog je privremeno zakljucan..." (od 12.05.2026; pre toga
+      // bila je engleska "Account temporarily locked"). FE detektuje prefix u
+      // oba jezika radi backwards-compat i prikazuje amber lockout alert.
+      if (isLockoutMessage(beMessage)) {
         setIsLocked(true);
         setServerError(beMessage);
       } else {
-        setServerError(beMessage || 'Pogrešan email ili lozinka. Pokušajte ponovo.');
+        setServerError(beMessage || 'Neispravan email ili lozinka. Pokusajte ponovo.');
       }
     } finally {
       setIsSubmitting(false);
@@ -91,7 +103,7 @@ export default function LoginPage() {
                   <Lock className="h-4 w-4" />
                   <AlertTitle>Nalog je privremeno zakljucan</AlertTitle>
                   <AlertDescription>
-                    {serverError} Pokusajte ponovo kasnije ili koristite "Zaboravili ste lozinku".
+                    Vise neuspesnih pokusaja je detektovano. Pokusajte ponovo kasnije ili koristite "Zaboravili ste lozinku".
                   </AlertDescription>
                 </Alert>
               ) : (

--- a/src/pages/Payments/NewPaymentPage.test.tsx
+++ b/src/pages/Payments/NewPaymentPage.test.tsx
@@ -76,6 +76,20 @@ function renderPage(route = '/payments/new') {
   );
 }
 
+/**
+ * Spec Sc 12 (Bug T2-005 12.05.2026): Submit forme otvara confirm dialog;
+ * "Potvrdi i nastavi" iz dialog-a otvara OTP modal. Pre fix-a klik na
+ * "Nastavi na verifikaciju" je direktno otvarao OTP. Helper kombinuje oba
+ * koraka da bismo zadrzali tedious test setup.
+ */
+async function submitAndConfirm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+  await waitFor(() => {
+    expect(screen.getByTestId('payment-confirm-dialog')).toBeInTheDocument();
+  });
+  await user.click(screen.getByTestId('payment-confirm-submit'));
+}
+
 describe('NewPaymentPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -182,15 +196,15 @@ describe('NewPaymentPage', () => {
       expect(screen.getByLabelText(/Iznos/i)).toBeInTheDocument();
     });
 
-    // Submit form
-    const submitBtn = screen.getByRole('button', { name: /Nastavi na verifikaciju/i });
-    await user.click(submitBtn);
+    // Negativan test — submit prazne forme: zod validacija mora pasti,
+    // confirm dialog NE sme da se prikaze.
+    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
 
     await waitFor(() => {
-      // Should show validation errors
       const errors = document.querySelectorAll('.text-destructive');
       expect(errors.length).toBeGreaterThan(0);
     });
+    expect(screen.queryByTestId('payment-confirm-dialog')).not.toBeInTheDocument();
   });
 
   it('opens verification modal on valid submission', async () => {
@@ -216,8 +230,7 @@ describe('NewPaymentPage', () => {
     await user.type(purposeInput, 'Test placanje');
 
     // Submit
-    const submitBtn = screen.getByRole('button', { name: /Nastavi na verifikaciju/i });
-    await user.click(submitBtn);
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();
@@ -342,13 +355,15 @@ describe('NewPaymentPage', () => {
     const purposeInput = screen.getByLabelText(/Svrha placanja/i);
     await user.type(purposeInput, 'Test');
 
-    const submitBtn = screen.getByRole('button', { name: /Nastavi na verifikaciju/i });
-    await user.click(submitBtn);
+    // Negativan test — validacija mora pasti, confirm dialog se NE otvara.
+    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
 
     await waitFor(() => {
       const errors = document.querySelectorAll('.text-destructive');
       expect(errors.length).toBeGreaterThan(0);
     });
+    // Confirm dialog ne sme da se prikaze posle invalid submit-a.
+    expect(screen.queryByTestId('payment-confirm-dialog')).not.toBeInTheDocument();
   });
 
   // ---------- Verification modal interaction ----------
@@ -377,8 +392,7 @@ describe('NewPaymentPage', () => {
     await user.type(purposeInput, 'Test placanje');
 
     // Submit
-    const submitBtn = screen.getByRole('button', { name: /Nastavi na verifikaciju/i });
-    await user.click(submitBtn);
+    await submitAndConfirm(user);
 
     // OTP modal opens
     await waitFor(() => {
@@ -407,7 +421,7 @@ describe('NewPaymentPage', () => {
     await user.clear(screen.getByLabelText(/Iznos/i));
     await user.type(screen.getByLabelText(/Iznos/i), '5000');
     await user.type(screen.getByLabelText(/Svrha placanja/i), 'Interbank payment');
-    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();
@@ -435,7 +449,7 @@ describe('NewPaymentPage', () => {
     await user.type(screen.getByLabelText(/Iznos/i), '5000');
     await user.type(screen.getByLabelText(/Svrha placanja/i), 'Test');
 
-    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();
@@ -632,8 +646,8 @@ describe('NewPaymentPage', () => {
     await user.type(amountInput, '5000');
     await user.type(screen.getByLabelText(/Svrha placanja/i), 'Test inter-bank');
 
-    // Submit i potvrdi OTP
-    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+    // Submit, potvrdi confirm dialog, pa OTP
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();
@@ -692,7 +706,7 @@ describe('NewPaymentPage', () => {
     await user.type(amountInput, '5000');
     await user.type(screen.getByLabelText(/Svrha placanja/i), 'Test');
 
-    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();
@@ -755,7 +769,7 @@ describe('NewPaymentPage', () => {
     await user.type(amountInput, '5000');
     await user.type(screen.getByLabelText(/Svrha placanja/i), 'Test');
 
-    await user.click(screen.getByRole('button', { name: /Nastavi na verifikaciju/i }));
+    await submitAndConfirm(user);
 
     await waitFor(() => {
       expect(screen.getByTestId('verification-modal')).toBeInTheDocument();

--- a/src/pages/Payments/NewPaymentPage.tsx
+++ b/src/pages/Payments/NewPaymentPage.tsx
@@ -29,7 +29,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import VerificationModal from '@/components/shared/VerificationModal';
-import { SendHorizonal, Wallet, ArrowRight, User, FileText, Hash, BookUser, CheckCircle2, X, Globe, Loader2, XCircle, AlertTriangle } from 'lucide-react';
+import { SendHorizonal, Wallet, ArrowRight, ArrowLeftRight, User, FileText, Hash, BookUser, CheckCircle2, X, Globe, Loader2, XCircle, AlertTriangle } from 'lucide-react';
 import { asArray, formatAmount, getErrorMessage } from '@/utils/formatters';
 
 const OUR_BANK_PREFIX = '222';
@@ -113,6 +113,12 @@ export default function NewPaymentPage() {
   const [savingRecipient, setSavingRecipient] = useState(false);
   const [interbankTracking, setInterbankTracking] = useState<InterbankPayment | null>(null);
   const [retryingStuck, setRetryingStuck] = useState(false);
+  // Spec Sc 12 (Bug T2-005 prijavljen 12.05.2026): Pre OTP modala mora se
+  // prikazati confirm dialog sa pregledom uplate. Za cross-currency intra-bank
+  // dodatno prikazuje napomenu da ce kurs i provizija biti primenjeni od strane
+  // BE-a. (Za inter-bank flow vec postoji 2PC stepper posle OTP-a — confirm
+  // dialog se isto prikazuje da bi UX bio uniforman.)
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
   const {
     register,
@@ -188,7 +194,16 @@ export default function NewPaymentPage() {
     return map;
   }, [accounts]);
 
+  // Spec Sc 12 (Bug T2-005): Submit forme NE otvara odmah OTP. Otvara confirm
+  // dialog sa pregledom uplate (iznos, valuta, primalac, FX napomena ako je
+  // cross-currency intra-bank). Korisnik klikom na "Potvrdi i nastavi" prelazi
+  // na OTP verifikaciju.
   const onSubmit = async () => {
+    setShowConfirmDialog(true);
+  };
+
+  const handleConfirmAndProceed = () => {
+    setShowConfirmDialog(false);
     setShowVerification(true);
   };
 
@@ -810,6 +825,131 @@ export default function NewPaymentPage() {
           </Card>
         </div>
       )}
+
+      {/* Spec Sc 12 (Bug T2-005): Confirm dialog pre OTP-a sa pregledom uplate */}
+      {showConfirmDialog && (() => {
+        const formData = getValues();
+        const fromAcc = accountLookup.get(formData.fromAccountNumber);
+        const isInter = isInterbank(formData.toAccountNumber || '');
+        const targetAcc = accountLookup.get(formData.toAccountNumber);
+        // Cross-currency: ako je primalac u nasoj banci i znamo mu valutu, a
+        // razlikuje se od izvora, prikazi FX napomenu. Za inter-bank ne znamo
+        // valutu primaoca pa prikazujemo generic 2PC napomenu.
+        const sourceCurrency = fromAcc?.currency || 'RSD';
+        const targetCurrency = targetAcc?.currency;
+        const isCrossCurrency = !isInter && targetCurrency && targetCurrency !== sourceCurrency;
+        return (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-fade-up">
+            <Card className="w-full max-w-md mx-4 rounded-2xl border shadow-2xl" data-testid="payment-confirm-dialog">
+              <CardContent className="p-6 space-y-5">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 text-white shadow-lg shadow-indigo-500/20">
+                    <CheckCircle2 className="h-5 w-5" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-base">Potvrdi placanje</h3>
+                    <p className="text-sm text-muted-foreground mt-0.5">
+                      Proverite detalje pre slanja na verifikaciju.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border bg-muted/30 p-4 space-y-3 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span className="text-muted-foreground">Sa racuna</span>
+                    <span className="font-mono text-xs">{formData.fromAccountNumber}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-muted-foreground">Primalac</span>
+                    <span className="font-medium">{formData.recipientName}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-muted-foreground">Racun primaoca</span>
+                    <span className="font-mono text-xs">{formData.toAccountNumber}</span>
+                  </div>
+                  <div className="flex items-center justify-between border-t pt-3">
+                    <span className="text-muted-foreground">Iznos</span>
+                    <span className="font-mono font-bold text-lg">
+                      {formatAmount(formData.amount)} {sourceCurrency}
+                    </span>
+                  </div>
+                  {formData.paymentPurpose && (
+                    <div className="flex items-start justify-between gap-3 border-t pt-3">
+                      <span className="text-muted-foreground shrink-0">Svrha</span>
+                      <span className="text-sm text-right">{formData.paymentPurpose}</span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Cross-currency napomena — Spec §253-263 (kursna lista, provizija) */}
+                {isCrossCurrency && (
+                  <div
+                    className="flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-50/70 dark:bg-amber-950/30 p-3"
+                    data-testid="payment-fx-notice"
+                  >
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-100 dark:bg-amber-900/40">
+                      <ArrowLeftRight className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-amber-700 dark:text-amber-300">
+                        Konverzija valute
+                      </p>
+                      <p className="text-xs text-amber-700/80 dark:text-amber-300/80">
+                        Vasa uplata <span className="font-mono">{sourceCurrency}</span> ce biti konvertovana u
+                        <span className="font-mono"> {targetCurrency}</span> po prodajnom kursu banke,
+                        uz proviziju za konverziju. Iznos koji primalac dobija zavisi od dnevnog kursa
+                        u trenutku obrade.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Inter-bank napomena — 2PC moze trajati do 2 min */}
+                {isInter && (
+                  <div
+                    className="flex items-start gap-3 rounded-xl border border-blue-500/30 bg-blue-50/70 dark:bg-blue-950/30 p-3"
+                    data-testid="payment-interbank-notice"
+                  >
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-blue-100 dark:bg-blue-900/40">
+                      <Globe className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-blue-700 dark:text-blue-300">
+                        Medjubankarsko placanje
+                      </p>
+                      <p className="text-xs text-blue-700/80 dark:text-blue-300/80">
+                        Racun primaoca pripada drugoj banci. Transakcija ide kroz 2PC protokol
+                        i moze trajati do 2 minuta. Status pratite u real-time-u nakon potvrde.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex gap-3">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="flex-1 h-11 rounded-xl"
+                    onClick={() => setShowConfirmDialog(false)}
+                    data-testid="payment-confirm-cancel"
+                  >
+                    Otkazi
+                  </Button>
+                  <Button
+                    type="button"
+                    className="flex-1 h-11 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-600 text-white font-semibold shadow-lg shadow-indigo-500/20"
+                    onClick={handleConfirmAndProceed}
+                    data-testid="payment-confirm-submit"
+                  >
+                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                    Potvrdi i nastavi
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        );
+      })()}
 
       <VerificationModal
         isOpen={showVerification}

--- a/src/pages/Savings/AdminSavingsDepositsPage.tsx
+++ b/src/pages/Savings/AdminSavingsDepositsPage.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react';
+import { Vault } from 'lucide-react';
+import { toast } from '@/lib/notify';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import PageHeader from '@/components/shared/PageHeader';
+import { savingsService } from '@/services/savingsService';
+import {
+  SavingsDepositDto,
+  PageDto,
+  SavingsDepositStatus,
+  STATUS_LABEL_SR,
+} from '@/types/savings';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+
+const STATUS_VARIANT: Record<SavingsDepositStatus, 'success' | 'secondary' | 'warning' | 'info'> = {
+  ACTIVE: 'success',
+  MATURED: 'secondary',
+  WITHDRAWN_EARLY: 'warning',
+  RENEWED: 'info',
+};
+
+function fmtAmount(n: number, c: string) {
+  try {
+    return new Intl.NumberFormat('sr-RS', { style: 'currency', currency: c, minimumFractionDigits: 2 }).format(n);
+  } catch {
+    return `${n.toFixed(2)} ${c}`;
+  }
+}
+
+export default function AdminSavingsDepositsPage() {
+  const [page, setPage] = useState<PageDto<SavingsDepositDto> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [filterStatus, setFilterStatus] = useState<string>('');
+  const [filterClientId, setFilterClientId] = useState<string>('');
+  const [pageNum, setPageNum] = useState(0);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const result = await savingsService.adminListAll({
+        status: filterStatus || undefined,
+        clientId: filterClientId ? Number(filterClientId) : undefined,
+        page: pageNum,
+        size: 20,
+      });
+      setPage(result);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Neuspeh ucitavanja');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [pageNum]);
+
+  return (
+    <div className="container mx-auto p-6 max-w-7xl">
+      <PageHeader
+        icon={<Vault />}
+        title="Svi orocni depoziti"
+        description="Admin/supervizor pregled svih stednih depozita u sistemu"
+      />
+
+      <Card className="p-4 mb-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+          <div>
+            <Label htmlFor="status-filter">Status</Label>
+            <select
+              id="status-filter"
+              className="w-full mt-1 px-3 py-2 border rounded-md bg-background"
+              data-testid="status-filter"
+              value={filterStatus}
+              onChange={e => setFilterStatus(e.target.value)}
+            >
+              <option value="">Svi</option>
+              <option value="ACTIVE">Aktivni</option>
+              <option value="MATURED">Dospeli</option>
+              <option value="WITHDRAWN_EARLY">Raskinuti</option>
+              <option value="RENEWED">Auto-obnovljeni</option>
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="client-filter">Client ID</Label>
+            <Input
+              id="client-filter"
+              type="number"
+              data-testid="client-filter"
+              value={filterClientId}
+              onChange={e => setFilterClientId(e.target.value)}
+            />
+          </div>
+          <Button onClick={() => { setPageNum(0); load(); }} data-testid="apply-filter">
+            Primeni filter
+          </Button>
+        </div>
+      </Card>
+
+      {loading ? (
+        <div className="text-center py-12 text-muted-foreground">Ucitavanje...</div>
+      ) : page && page.content.length > 0 ? (
+        <>
+          <Card className="overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Klijent</TableHead>
+                  <TableHead className="text-right">Glavnica</TableHead>
+                  <TableHead className="text-center">Rok</TableHead>
+                  <TableHead className="text-center">Stopa</TableHead>
+                  <TableHead className="text-center">Status</TableHead>
+                  <TableHead>Datum otvaranja</TableHead>
+                  <TableHead>Dospece</TableHead>
+                  <TableHead className="text-right">Isplaceno kamata</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {page.content.map(d => (
+                  <TableRow key={d.id} data-testid={`admin-deposit-row-${d.id}`}>
+                    <TableCell className="tabular-nums">{d.id}</TableCell>
+                    <TableCell>
+                      {d.clientName}{' '}
+                      <span className="text-muted-foreground">#{d.clientId}</span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {fmtAmount(d.principalAmount, d.currencyCode)}
+                    </TableCell>
+                    <TableCell className="text-center">{d.termMonths}m</TableCell>
+                    <TableCell className="text-center">{d.annualInterestRate}%</TableCell>
+                    <TableCell className="text-center">
+                      <Badge variant={STATUS_VARIANT[d.status]}>{STATUS_LABEL_SR[d.status]}</Badge>
+                    </TableCell>
+                    <TableCell>{new Date(d.startDate).toLocaleDateString('sr-RS')}</TableCell>
+                    <TableCell>{new Date(d.maturityDate).toLocaleDateString('sr-RS')}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {fmtAmount(d.totalInterestPaid, d.currencyCode)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Card>
+          <div className="flex justify-between items-center mt-4">
+            <span className="text-sm text-muted-foreground">
+              Strana {page.number + 1} od {page.totalPages} ({page.totalElements} ukupno)
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page.number === 0}
+                onClick={() => setPageNum(page.number - 1)}
+              >
+                Prethodna
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page.number >= page.totalPages - 1}
+                onClick={() => setPageNum(page.number + 1)}
+              >
+                Sledeca
+              </Button>
+            </div>
+          </div>
+        </>
+      ) : (
+        <Card className="p-12 text-center text-muted-foreground">
+          Nema depozita za prikazane filtere.
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Savings/AdminSavingsDepositsPage.tsx
+++ b/src/pages/Savings/AdminSavingsDepositsPage.tsx
@@ -9,9 +9,9 @@ import { Badge } from '@/components/ui/badge';
 import PageHeader from '@/components/shared/PageHeader';
 import { savingsService } from '@/services/savingsService';
 import {
-  SavingsDepositDto,
-  PageDto,
-  SavingsDepositStatus,
+  type SavingsDepositDto,
+  type PageDto,
+  type SavingsDepositStatus,
   STATUS_LABEL_SR,
 } from '@/types/savings';
 import {

--- a/src/pages/Savings/AdminSavingsRatesPage.tsx
+++ b/src/pages/Savings/AdminSavingsRatesPage.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import PageHeader from '@/components/shared/PageHeader';
 import { savingsService } from '@/services/savingsService';
-import { SavingsRateDto, TERM_OPTIONS } from '@/types/savings';
+import { type SavingsRateDto, TERM_OPTIONS } from '@/types/savings';
 import {
   Table,
   TableHeader,

--- a/src/pages/Savings/AdminSavingsRatesPage.tsx
+++ b/src/pages/Savings/AdminSavingsRatesPage.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState, useMemo } from 'react';
+import { Percent, Edit, X } from 'lucide-react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { toast } from '@/lib/notify';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import PageHeader from '@/components/shared/PageHeader';
+import { savingsService } from '@/services/savingsService';
+import { SavingsRateDto, TERM_OPTIONS } from '@/types/savings';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+
+interface EditState {
+  currencyCode: string;
+  termMonths: number;
+  annualRate: number;
+}
+
+export default function AdminSavingsRatesPage() {
+  const [rates, setRates] = useState<SavingsRateDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<EditState | null>(null);
+  const [newRate, setNewRate] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const all = await savingsService.adminListAllRates();
+      setRates(all);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Neuspeh ucitavanja stopa');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const activeRates = useMemo(() => rates.filter(r => r.active), [rates]);
+  const historyRates = useMemo(() => rates.filter(r => !r.active).sort((a, b) =>
+    new Date(b.effectiveFrom).getTime() - new Date(a.effectiveFrom).getTime()
+  ), [rates]);
+
+  const byCurrency = useMemo(() => {
+    const map = new Map<string, Map<number, SavingsRateDto>>();
+    for (const r of activeRates) {
+      if (!map.has(r.currencyCode)) map.set(r.currencyCode, new Map());
+      map.get(r.currencyCode)!.set(r.termMonths, r);
+    }
+    return map;
+  }, [activeRates]);
+
+  const handleSave = async () => {
+    if (!editing) return;
+    const rate = Number(newRate);
+    if (!Number.isFinite(rate) || rate <= 0 || rate > 50) {
+      toast.error('Stopa mora biti izmedju 0 i 50%');
+      return;
+    }
+    setSaving(true);
+    try {
+      await savingsService.adminUpsertRate({
+        currencyCode: editing.currencyCode,
+        termMonths: editing.termMonths,
+        annualRate: rate,
+      });
+      toast.success(`Stopa azurirana: ${editing.currencyCode} ${editing.termMonths}m → ${rate}%`);
+      setEditing(null);
+      setNewRate('');
+      await load();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Azuriranje stope nije uspelo');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openEdit = (currencyCode: string, termMonths: number, currentRate: number) => {
+    setEditing({ currencyCode, termMonths, annualRate: currentRate });
+    setNewRate(String(currentRate));
+  };
+
+  const closeDialog = () => {
+    setEditing(null);
+    setNewRate('');
+  };
+
+  return (
+    <div className="container mx-auto p-6 max-w-7xl">
+      <PageHeader
+        icon={<Percent />}
+        title="Kamatne stope stednje"
+        description="Upravljanje vazecim stopama za sve valute i rokove"
+      />
+
+      {loading ? (
+        <div className="text-center py-12 text-muted-foreground">Ucitavanje...</div>
+      ) : (
+        <>
+          <Card className="p-4 mb-6 overflow-x-auto">
+            <h3 className="text-lg font-semibold mb-4">Vazece stope</h3>
+            {byCurrency.size === 0 ? (
+              <p className="text-muted-foreground text-sm">Nema definisanih stopa.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Valuta</TableHead>
+                    {TERM_OPTIONS.map(t => (
+                      <TableHead key={t} className="text-center">{t} meseci</TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {Array.from(byCurrency.entries()).sort(([a], [b]) => a.localeCompare(b)).map(([code, termMap]) => (
+                    <TableRow key={code}>
+                      <TableCell className="font-medium">{code}</TableCell>
+                      {TERM_OPTIONS.map(t => {
+                        const r = termMap.get(t);
+                        return (
+                          <TableCell key={t} className="text-center" data-testid={`rate-${code}-${t}`}>
+                            {r ? (
+                              <button
+                                onClick={() => openEdit(code, t, r.annualRate)}
+                                className="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-muted transition-colors"
+                                data-testid={`edit-rate-${code}-${t}`}
+                              >
+                                <span className="tabular-nums">{r.annualRate}%</span>
+                                <Edit className="w-3 h-3 opacity-50" />
+                              </button>
+                            ) : (
+                              <span className="text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </Card>
+
+          <Card className="p-4">
+            <h3 className="text-lg font-semibold mb-4">Istorija promena</h3>
+            {historyRates.length === 0 ? (
+              <p className="text-muted-foreground text-sm">Jos nema deaktiviranih stopa.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Valuta</TableHead>
+                    <TableHead className="text-center">Rok</TableHead>
+                    <TableHead className="text-center">Stopa</TableHead>
+                    <TableHead>Vazila od</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {historyRates.map(r => (
+                    <TableRow key={r.id}>
+                      <TableCell>{r.currencyCode}</TableCell>
+                      <TableCell className="text-center">{r.termMonths}m</TableCell>
+                      <TableCell className="text-center tabular-nums">{r.annualRate}%</TableCell>
+                      <TableCell>{new Date(r.effectiveFrom).toLocaleDateString('sr-RS')}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </Card>
+        </>
+      )}
+
+      <Dialog.Root open={!!editing} onOpenChange={open => !open && closeDialog()}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-[60] w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-background shadow-2xl">
+            <div className="flex items-center justify-between p-6 pb-4">
+              <Dialog.Title className="text-lg font-semibold">
+                Azuriraj stopu: {editing?.currencyCode} {editing?.termMonths} meseci
+              </Dialog.Title>
+              <Dialog.Close asChild>
+                <button className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+                  <X className="w-4 h-4" />
+                </button>
+              </Dialog.Close>
+            </div>
+
+            <div className="px-6 pb-2 space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Trenutna stopa: <span className="font-medium">{editing?.annualRate}% p.a.</span>
+              </p>
+              <div>
+                <Label htmlFor="new-rate">Nova godisnja stopa (%)</Label>
+                <Input
+                  id="new-rate"
+                  type="number"
+                  step="0.01"
+                  value={newRate}
+                  onChange={e => setNewRate(e.target.value)}
+                  data-testid="new-rate-input"
+                  className="mt-1"
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Stara stopa ce biti deaktivirana, postojeci depoziti zadrzavaju svoju originalnu stopu.
+                Nova stopa vazi za nove depozite i auto-obnove.
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2 p-6 pt-4">
+              <Button variant="outline" onClick={closeDialog} disabled={saving}>
+                Odustani
+              </Button>
+              <Button onClick={handleSave} data-testid="save-rate" disabled={saving}>
+                {saving ? 'Cuvanje...' : 'Sacuvaj'}
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/src/pages/Savings/SavingsDetailsPage.tsx
+++ b/src/pages/Savings/SavingsDetailsPage.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from '@/lib/notify';
+import { AlertTriangle, PiggyBank, RotateCw, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import PageHeader from '@/components/shared/PageHeader';
+import VerificationModal from '@/components/shared/VerificationModal';
+import { savingsService } from '@/services/savingsService';
+import type { SavingsDepositDto, SavingsTransactionDto, SavingsDepositStatus } from '@/types/savings';
+import { STATUS_LABEL_SR, TRANSACTION_TYPE_LABEL_SR } from '@/types/savings';
+
+const STATUS_VARIANT: Record<SavingsDepositStatus, 'success' | 'secondary' | 'warning' | 'info'> = {
+  ACTIVE: 'success',
+  MATURED: 'secondary',
+  WITHDRAWN_EARLY: 'warning',
+  RENEWED: 'info',
+};
+
+function fmtAmount(n: number, c: string) {
+  try {
+    return new Intl.NumberFormat('sr-RS', {
+      style: 'currency',
+      currency: c,
+      minimumFractionDigits: 2,
+    }).format(n);
+  } catch {
+    return `${n.toFixed(2)} ${c}`;
+  }
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  );
+}
+
+interface WithdrawConfirmProps {
+  deposit: SavingsDepositDto;
+  penalty: number;
+  onClose: () => void;
+  onConfirm: (otpCode: string) => Promise<void>;
+  submitting: boolean;
+}
+
+function WithdrawConfirm({ deposit, penalty, onClose, onConfirm, submitting }: WithdrawConfirmProps) {
+  const [showOtp, setShowOtp] = useState(false);
+  const returned = deposit.principalAmount - penalty;
+
+  if (showOtp) {
+    return (
+      <VerificationModal
+        isOpen={showOtp}
+        onVerified={onConfirm}
+        onClose={() => {
+          setShowOtp(false);
+          onClose();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <Card className="max-w-md w-full p-6">
+        <div className="flex items-center gap-3 mb-4 text-amber-600 dark:text-amber-400">
+          <AlertTriangle className="w-6 h-6" />
+          <h3 className="text-lg font-semibold">Raskid pre dospeca</h3>
+        </div>
+        <p className="text-sm text-muted-foreground mb-4">
+          Glavnica ce biti vracena na povezani racun, ali ostvarujete penal od 1% glavnice. Buduce
+          kamate se gube.
+        </p>
+        <dl className="space-y-2 text-sm mb-4 border rounded-md p-3">
+          <Row
+            label="Glavnica"
+            value={`${deposit.principalAmount.toFixed(2)} ${deposit.currencyCode}`}
+          />
+          <Row label="Penal (1%)" value={`-${penalty.toFixed(2)} ${deposit.currencyCode}`} />
+          <Row label="Vraca se" value={`${returned.toFixed(2)} ${deposit.currencyCode}`} />
+        </dl>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            className="flex-1"
+            disabled={submitting}
+          >
+            Odustani
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => setShowOtp(true)}
+            className="flex-1"
+            disabled={submitting}
+            data-testid="confirm-withdraw"
+          >
+            Potvrdi raskid
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default function SavingsDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [deposit, setDeposit] = useState<SavingsDepositDto | null>(null);
+  const [transactions, setTransactions] = useState<SavingsTransactionDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const depositId = Number(id);
+
+  const refresh = async () => {
+    try {
+      const [d, txs] = await Promise.all([
+        savingsService.getDeposit(depositId),
+        savingsService.getTransactions(depositId),
+      ]);
+      setDeposit(d);
+      setTransactions(txs);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Neuspeh ucitavanja depozita');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!Number.isFinite(depositId) || isNaN(depositId)) {
+      navigate('/savings');
+      return;
+    }
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [depositId]);
+
+  const handleToggleAutoRenew = async (autoRenew: boolean) => {
+    if (!deposit) return;
+    try {
+      const updated = await savingsService.toggleAutoRenew(deposit.id, autoRenew);
+      setDeposit(updated);
+      toast.success(autoRenew ? 'Auto-obnova ukljucena' : 'Auto-obnova iskljucena');
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Promena nije uspela');
+    }
+  };
+
+  const handleWithdrawConfirmed = async (otpCode: string) => {
+    if (!deposit) return;
+    setSubmitting(true);
+    try {
+      const updated = await savingsService.withdrawEarly(deposit.id, otpCode);
+      setDeposit(updated);
+      await refresh();
+      toast.success('Depozit raskinut, glavnica vracena na povezani racun');
+      setShowWithdrawDialog(false);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Raskid nije uspeo');
+      throw e;
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="container mx-auto p-6 text-center text-muted-foreground">Ucitavanje...</div>;
+  }
+  if (!deposit) {
+    return <div className="container mx-auto p-6 text-center text-muted-foreground">Depozit ne postoji.</div>;
+  }
+
+  const penalty = deposit.principalAmount * 0.01;
+
+  return (
+    <div className="container mx-auto p-6 max-w-7xl">
+      <div className="mb-6">
+        <PageHeader
+          icon={<PiggyBank className="h-5 w-5" />}
+          title={`Depozit #${deposit.id}`}
+          description={`${deposit.termMonths} meseci, ${deposit.annualInterestRate}% p.a.`}
+          actions={
+            deposit.status === 'ACTIVE' ? (
+              <Button
+                variant="destructive"
+                onClick={() => setShowWithdrawDialog(true)}
+                data-testid="open-withdraw"
+              >
+                <X className="w-4 h-4 mr-2" /> Raskini ranije
+              </Button>
+            ) : undefined
+          }
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Details card */}
+        <Card className="p-6">
+          <div className="flex justify-between mb-4">
+            <h3 className="text-lg font-semibold">Detalji</h3>
+            <Badge variant={STATUS_VARIANT[deposit.status]}>{STATUS_LABEL_SR[deposit.status]}</Badge>
+          </div>
+          <dl className="space-y-2 text-sm">
+            <Row label="Glavnica" value={fmtAmount(deposit.principalAmount, deposit.currencyCode)} />
+            <Row label="Kamatna stopa" value={`${deposit.annualInterestRate}% p.a.`} />
+            <Row label="Rok" value={`${deposit.termMonths} meseci`} />
+            <Row
+              label="Datum otvaranja"
+              value={new Date(deposit.startDate).toLocaleDateString('sr-RS')}
+            />
+            <Row
+              label="Datum dospeca"
+              value={new Date(deposit.maturityDate).toLocaleDateString('sr-RS')}
+            />
+            <Row
+              label="Sledeca kamata"
+              value={new Date(deposit.nextInterestPaymentDate).toLocaleDateString('sr-RS')}
+            />
+            <Row label="Povezani racun" value={deposit.linkedAccountNumber} />
+            <Row
+              label="Isplaceno kamata"
+              value={fmtAmount(deposit.totalInterestPaid, deposit.currencyCode)}
+            />
+          </dl>
+
+          {deposit.status === 'ACTIVE' && (
+            <div className="flex items-center justify-between border-t mt-4 pt-4">
+              <div>
+                <div className="font-medium text-sm">Auto-obnova</div>
+                <p className="text-xs text-muted-foreground">Produzi na isti rok po vazecoj stopi</p>
+              </div>
+              <Switch
+                checked={deposit.autoRenew}
+                onCheckedChange={handleToggleAutoRenew}
+                data-testid="auto-renew-switch"
+              />
+            </div>
+          )}
+        </Card>
+
+        {/* Transaction timeline */}
+        <Card className="p-6" data-testid="timeline">
+          <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+            <RotateCw className="w-5 h-5" /> Istorija transakcija
+          </h3>
+          {transactions.length === 0 ? (
+            <p className="text-muted-foreground text-sm">Nema transakcija jos.</p>
+          ) : (
+            <ul className="space-y-3">
+              {transactions.map(tx => (
+                <li key={tx.id} className="border-l-2 border-indigo-500 pl-3 py-1">
+                  <div className="flex justify-between text-sm">
+                    <span className="font-medium">{TRANSACTION_TYPE_LABEL_SR[tx.type]}</span>
+                    <span className="tabular-nums">{fmtAmount(tx.amount, tx.currencyCode)}</span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {new Date(tx.processedDate).toLocaleDateString('sr-RS')} — {tx.description}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </div>
+
+      {showWithdrawDialog && (
+        <WithdrawConfirm
+          deposit={deposit}
+          penalty={penalty}
+          onClose={() => setShowWithdrawDialog(false)}
+          onConfirm={handleWithdrawConfirmed}
+          submitting={submitting}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/Savings/SavingsListPage.tsx
+++ b/src/pages/Savings/SavingsListPage.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PiggyBank, Plus, Calendar, Percent, TrendingUp, Vault } from 'lucide-react';
+import { toast } from '@/lib/notify';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import PageHeader from '@/components/shared/PageHeader';
+import { savingsService } from '@/services/savingsService';
+import type { SavingsDepositDto, SavingsDepositStatus } from '@/types/savings';
+import { STATUS_LABEL_SR } from '@/types/savings';
+
+const STATUS_VARIANT: Record<SavingsDepositStatus, 'success' | 'secondary' | 'warning' | 'info'> = {
+  ACTIVE: 'success',
+  MATURED: 'secondary',
+  WITHDRAWN_EARLY: 'warning',
+  RENEWED: 'info',
+};
+
+function formatAmount(n: number, code: string): string {
+  try {
+    return new Intl.NumberFormat('sr-RS', {
+      style: 'currency',
+      currency: code,
+      minimumFractionDigits: 2,
+    }).format(n);
+  } catch {
+    return `${n.toFixed(2)} ${code}`;
+  }
+}
+
+function daysUntil(dateIso: string): number {
+  const d = new Date(dateIso);
+  const now = new Date();
+  return Math.ceil((d.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function KpiChip({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="bg-card border rounded-lg p-3 flex items-center gap-3">
+      <div className="w-10 h-10 rounded-full bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 flex items-center justify-center">
+        {icon}
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground">{label}</div>
+        <div className="font-semibold tabular-nums">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function SavingsListPage() {
+  const navigate = useNavigate();
+  const [deposits, setDeposits] = useState<SavingsDepositDto[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    savingsService
+      .listMyDeposits()
+      .then(setDeposits)
+      .catch(() => toast.error('Neuspeh ucitavanja stednje'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const active = useMemo(() => deposits.filter(d => d.status === 'ACTIVE'), [deposits]);
+
+  const totalPrincipal = useMemo(
+    () => active.reduce((sum, d) => sum + d.principalAmount, 0),
+    [active]
+  );
+  const totalInterest = useMemo(
+    () => deposits.reduce((sum, d) => sum + d.totalInterestPaid, 0),
+    [deposits]
+  );
+  const nextMaturityDays = useMemo(() => {
+    if (active.length === 0) return null;
+    return Math.min(...active.map(d => daysUntil(d.maturityDate)));
+  }, [active]);
+
+  const defaultCurrency = deposits[0]?.currencyCode ?? 'RSD';
+
+  return (
+    <div className="container mx-auto p-6 max-w-7xl">
+      <div className="mb-6">
+        <PageHeader
+          icon={<PiggyBank className="h-5 w-5" />}
+          title="Stednja"
+          description="Vasi orocni depoziti — pratite stanje, kamatu i dospece"
+          actions={
+            <Button onClick={() => navigate('/savings/new')} data-testid="open-new-deposit">
+              <Plus className="w-4 h-4 mr-2" /> Novi depozit
+            </Button>
+          }
+        />
+      </div>
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <KpiChip
+          icon={<Vault className="w-5 h-5" />}
+          label="Ukupno orocno"
+          value={formatAmount(totalPrincipal, defaultCurrency)}
+        />
+        <KpiChip
+          icon={<TrendingUp className="w-5 h-5" />}
+          label="Ukupno kamata"
+          value={formatAmount(totalInterest, defaultCurrency)}
+        />
+        <KpiChip
+          icon={<Calendar className="w-5 h-5" />}
+          label="Sledeci dospece"
+          value={nextMaturityDays !== null ? `za ${nextMaturityDays} dana` : '-'}
+        />
+        <KpiChip
+          icon={<Percent className="w-5 h-5" />}
+          label="Aktivnih depozita"
+          value={`${active.length}`}
+        />
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-muted-foreground">Ucitavanje...</div>
+      ) : deposits.length === 0 ? (
+        <Card className="p-12 text-center">
+          <PiggyBank className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
+          <h3 className="text-xl font-semibold mb-2">Nemate aktivnih depozita</h3>
+          <p className="text-muted-foreground mb-4">
+            Otvorite svoj prvi oroceni depozit da pocnete da zaradjujete kamatu na svoju ustedu.
+          </p>
+          <Button onClick={() => navigate('/savings/new')}>
+            <Plus className="w-4 h-4 mr-2" /> Otvori prvi depozit
+          </Button>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {deposits.map(d => (
+            <Card
+              key={d.id}
+              className="p-6 hover:shadow-lg transition-shadow cursor-pointer"
+              onClick={() => navigate(`/savings/${d.id}`)}
+              data-testid={`deposit-card-${d.id}`}
+            >
+              <div className="flex justify-between items-start mb-3">
+                <div>
+                  <div className="text-sm text-muted-foreground">Depozit #{d.id}</div>
+                  <div className="text-2xl font-bold tabular-nums">
+                    {formatAmount(d.principalAmount, d.currencyCode)}
+                  </div>
+                </div>
+                <Badge variant={STATUS_VARIANT[d.status]}>{STATUS_LABEL_SR[d.status]}</Badge>
+              </div>
+              <dl className="space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Stopa</dt>
+                  <dd>{d.annualInterestRate}% p.a.</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Rok</dt>
+                  <dd>{d.termMonths} meseci</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Dospece</dt>
+                  <dd>{new Date(d.maturityDate).toLocaleDateString('sr-RS')}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-muted-foreground">Isplaceno kamata</dt>
+                  <dd className="tabular-nums">{formatAmount(d.totalInterestPaid, d.currencyCode)}</dd>
+                </div>
+                {d.autoRenew && (
+                  <div className="text-xs text-indigo-600 dark:text-indigo-400 mt-2">
+                    Auto-obnova aktivna
+                  </div>
+                )}
+              </dl>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Savings/SavingsNewDepositPage.tsx
+++ b/src/pages/Savings/SavingsNewDepositPage.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { PiggyBank } from 'lucide-react';
+import { toast } from '@/lib/notify';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import PageHeader from '@/components/shared/PageHeader';
+import VerificationModal from '@/components/shared/VerificationModal';
+import { savingsService } from '@/services/savingsService';
+import { accountService } from '@/services/accountService';
+import { SavingsCalculator } from '@/components/savings/SavingsCalculator';
+import type { SavingsRateDto } from '@/types/savings';
+import { MIN_DEPOSIT_AMOUNT, TERM_OPTIONS } from '@/types/savings';
+import type { Account } from '@/types/celina2';
+
+const schema = z.object({
+  sourceAccountId: z.number({ message: 'Izaberite izvorni racun' }),
+  linkedAccountId: z.number({ message: 'Izaberite povezani racun' }),
+  principalAmount: z.number().positive('Iznos mora biti pozitivan'),
+  termMonths: z
+    .number()
+    .refine(v => [3, 6, 12, 24, 36].includes(v), 'Rok mora biti 3/6/12/24/36 meseci'),
+  autoRenew: z.boolean(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function SavingsNewDepositPage() {
+  const navigate = useNavigate();
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [rates, setRates] = useState<SavingsRateDto[]>([]);
+  const [showOtp, setShowOtp] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const {
+    register,
+    watch,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      termMonths: 12,
+      autoRenew: false,
+      principalAmount: 0,
+    },
+  });
+
+  const sourceAccountId = watch('sourceAccountId');
+  const principal = watch('principalAmount');
+  const termMonths = watch('termMonths');
+  const autoRenew = watch('autoRenew');
+  const linkedAccountId = watch('linkedAccountId');
+
+  useEffect(() => {
+    accountService
+      .getMyAccounts()
+      .then(all => {
+        const active = all.filter(a => a.status === 'ACTIVE');
+        setAccounts(active);
+      })
+      .catch(() => toast.error('Neuspeh ucitavanja racuna'));
+
+    savingsService
+      .getRates()
+      .then(setRates)
+      .catch(() => toast.error('Neuspeh ucitavanja stopa'));
+  }, []);
+
+  const sourceAccount = useMemo(
+    () => accounts.find(a => a.id === sourceAccountId),
+    [accounts, sourceAccountId]
+  );
+  const currencyCode = sourceAccount?.currency?.code ?? 'RSD';
+  const minAmount = MIN_DEPOSIT_AMOUNT[currencyCode] ?? 100;
+
+  const annualRate = useMemo(() => {
+    const r = rates.find(rt => rt.currencyCode === currencyCode && rt.termMonths === termMonths);
+    return r?.annualRate ?? 0;
+  }, [rates, currencyCode, termMonths]);
+
+  const onSubmit = (data: FormData) => {
+    if (data.principalAmount < minAmount) {
+      toast.error(`Minimalan iznos u ${currencyCode} je ${minAmount}`);
+      return;
+    }
+    setShowOtp(true);
+  };
+
+  const handleOtpVerified = async (otpCode: string) => {
+    const data = watch();
+    setSubmitting(true);
+    try {
+      const result = await savingsService.openDeposit({
+        sourceAccountId: data.sourceAccountId,
+        linkedAccountId: data.linkedAccountId,
+        principalAmount: data.principalAmount,
+        termMonths: data.termMonths,
+        autoRenew: data.autoRenew,
+        otpCode,
+      });
+      toast.success('Depozit otvoren — Vasi novci ce raditi za vas');
+      navigate(`/savings/${result.id}`);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } } };
+      toast.error(err?.response?.data?.message ?? 'Otvaranje depozita nije uspelo');
+      // Re-throw so VerificationModal can handle the error state (show error, decrement attempts)
+      throw e;
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const sameAccountOptions = accounts.filter(a => a.currency?.code === currencyCode);
+
+  return (
+    <div className="container mx-auto p-6 max-w-7xl">
+      <div className="mb-6">
+        <PageHeader
+          icon={<PiggyBank className="h-5 w-5" />}
+          title="Novi oroceni depozit"
+          description="Glavnica zakljucana, mesecna kamata na povezani racun"
+        />
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <Card className="lg:col-span-2 p-6 space-y-4">
+          {/* Source account */}
+          <div>
+            <Label htmlFor="sourceAccount">Izvorni racun (sa kog se uzima glavnica)</Label>
+            <select
+              id="sourceAccount"
+              className="w-full mt-1 px-3 py-2 border rounded-md bg-background text-sm"
+              data-testid="source-account"
+              value={sourceAccountId ?? ''}
+              onChange={e => {
+                const id = Number(e.target.value);
+                setValue('sourceAccountId', id);
+                // Default linked to same account if not yet chosen
+                if (!linkedAccountId) setValue('linkedAccountId', id);
+              }}
+            >
+              <option value="">-- Izaberi --</option>
+              {accounts.map(a => (
+                <option key={a.id} value={a.id}>
+                  {a.accountNumber} ({a.currency.code}) — {a.availableBalance.toFixed(2)}
+                </option>
+              ))}
+            </select>
+            {errors.sourceAccountId && (
+              <p className="text-red-500 text-xs mt-1">{errors.sourceAccountId.message}</p>
+            )}
+          </div>
+
+          {/* Principal amount */}
+          <div>
+            <Label htmlFor="principal">
+              Iznos (min. {minAmount} {currencyCode})
+            </Label>
+            <Input
+              id="principal"
+              type="number"
+              step="0.01"
+              min={0}
+              data-testid="principal-input"
+              {...register('principalAmount', { valueAsNumber: true })}
+            />
+            {errors.principalAmount && (
+              <p className="text-red-500 text-xs mt-1">{errors.principalAmount.message}</p>
+            )}
+          </div>
+
+          {/* Term selector */}
+          <div>
+            <Label>Rok (meseci)</Label>
+            <div className="grid grid-cols-5 gap-2 mt-1">
+              {TERM_OPTIONS.map(t => {
+                const r = rates.find(rt => rt.currencyCode === currencyCode && rt.termMonths === t);
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    data-testid={`term-${t}`}
+                    onClick={() => setValue('termMonths', t)}
+                    className={`p-3 border rounded-md transition-colors text-sm ${
+                      termMonths === t
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-background hover:bg-muted'
+                    }`}
+                  >
+                    <div className="font-semibold">{t}m</div>
+                    <div className="text-xs opacity-75">{r ? `${r.annualRate}%` : '-'}</div>
+                  </button>
+                );
+              })}
+            </div>
+            {errors.termMonths && (
+              <p className="text-red-500 text-xs mt-1">{errors.termMonths.message}</p>
+            )}
+          </div>
+
+          {/* Linked account */}
+          <div>
+            <Label htmlFor="linkedAccount">Povezani racun (gde idu kamate)</Label>
+            <select
+              id="linkedAccount"
+              className="w-full mt-1 px-3 py-2 border rounded-md bg-background text-sm"
+              data-testid="linked-account"
+              value={linkedAccountId ?? ''}
+              onChange={e => setValue('linkedAccountId', Number(e.target.value))}
+            >
+              <option value="">-- Izaberi --</option>
+              {sameAccountOptions.map(a => (
+                <option key={a.id} value={a.id}>
+                  {a.accountNumber}
+                </option>
+              ))}
+            </select>
+            {errors.linkedAccountId && (
+              <p className="text-red-500 text-xs mt-1">{errors.linkedAccountId.message}</p>
+            )}
+          </div>
+
+          {/* Auto-renew toggle */}
+          <div className="flex items-center justify-between border-t pt-4">
+            <div>
+              <Label>Auto-obnova na dospece</Label>
+              <p className="text-xs text-muted-foreground">
+                Glavnica se automatski produzava po vazecoj stopi
+              </p>
+            </div>
+            <Switch
+              checked={autoRenew}
+              onCheckedChange={v => setValue('autoRenew', v)}
+              data-testid="auto-renew-toggle"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={submitting}
+            data-testid="submit-deposit"
+          >
+            Otvori depozit
+          </Button>
+        </Card>
+
+        {/* Calculator sidebar */}
+        <SavingsCalculator
+          principal={principal || 0}
+          annualRate={annualRate}
+          termMonths={termMonths}
+          currencyCode={currencyCode}
+        />
+      </form>
+
+      <VerificationModal
+        isOpen={showOtp}
+        onVerified={handleOtpVerified}
+        onClose={() => setShowOtp(false)}
+      />
+    </div>
+  );
+}

--- a/src/pages/Savings/SavingsNewDepositPage.tsx
+++ b/src/pages/Savings/SavingsNewDepositPage.tsx
@@ -78,7 +78,10 @@ export default function SavingsNewDepositPage() {
     () => accounts.find(a => a.id === sourceAccountId),
     [accounts, sourceAccountId]
   );
-  const currencyCode = sourceAccount?.currency?.code ?? 'RSD';
+  // Account.currency je tipa Currency (string union "RSD"/"EUR"/...), nije objekat.
+  // Fix 12.05.2026 vece: pre fix-a sourceAccount.currency.code je radjeno kao
+  // da je objekat sto je TS error sa verbatimModuleSyntax.
+  const currencyCode = sourceAccount?.currency ?? 'RSD';
   const minAmount = MIN_DEPOSIT_AMOUNT[currencyCode] ?? 100;
 
   const annualRate = useMemo(() => {
@@ -118,7 +121,7 @@ export default function SavingsNewDepositPage() {
     }
   };
 
-  const sameAccountOptions = accounts.filter(a => a.currency?.code === currencyCode);
+  const sameAccountOptions = accounts.filter(a => a.currency === currencyCode);
 
   return (
     <div className="container mx-auto p-6 max-w-7xl">
@@ -150,7 +153,7 @@ export default function SavingsNewDepositPage() {
               <option value="">-- Izaberi --</option>
               {accounts.map(a => (
                 <option key={a.id} value={a.id}>
-                  {a.accountNumber} ({a.currency.code}) — {a.availableBalance.toFixed(2)}
+                  {a.accountNumber} ({a.currency}) — {a.availableBalance.toFixed(2)}
                 </option>
               ))}
             </select>

--- a/src/pages/Securities/SecuritiesListPage.tsx
+++ b/src/pages/Securities/SecuritiesListPage.tsx
@@ -21,6 +21,8 @@ import {
   ArrowDown,
   SlidersHorizontal,
   Orbit,
+  X,
+  Clock,
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import type { Listing, PaginatedResponse, Exchange } from '@/types/celina3';
@@ -141,6 +143,15 @@ export default function SecuritiesListPage() {
   const [data, setData] = useState<PaginatedResponse<Listing> | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  // Spec Sc 16/17 (Bug T4-004/T4-005 prijavljen 12.05.2026):
+  //   Sc 16: "klikne na osvezavanje podataka → prikazuje se novo vreme
+  //          poslednjeg osvezavanja"
+  //   Sc 17: "prodje definisani vremenski interval bez korisničke akcije →
+  //          podaci se automatski osvezavaju"
+  // lastRefreshAt belezi kad je poslednji uspesan fetch zavrsen — auto refresh
+  // svakih 30s + klik na "Osvezi cene" oba azuriraju ovu vrednost.
+  const [lastRefreshAt, setLastRefreshAt] = useState<Date | null>(null);
+  const AUTO_REFRESH_MS = 30_000;
 
   // Advanced filters
   const [showFilters, setShowFilters] = useState(false);
@@ -190,13 +201,15 @@ export default function SecuritiesListPage() {
   const priceRangeError = debouncedFilters.priceMin && debouncedFilters.priceMax
     && Number(debouncedFilters.priceMin) > Number(debouncedFilters.priceMax);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (opts?: { silent?: boolean }) => {
     if (priceRangeError) {
       setData({ content: [], totalPages: 0, totalElements: 0, number: 0, size: PAGE_SIZE } as PaginatedResponse<Listing>);
       setLoading(false);
       return;
     }
-    setLoading(true);
+    // Auto-refresh poziv ide "silent" — ne flashujemo skeleton (lose UX da
+    // tabela treperi svakih 30s).
+    if (!opts?.silent) setLoading(true);
     try {
       const filters: Record<string, string | number> = {};
       if (debouncedFilters.exchangePrefix) filters.exchangePrefix = debouncedFilters.exchangePrefix;
@@ -208,15 +221,37 @@ export default function SecuritiesListPage() {
       const result = await listingService.getAll(activeTab, debouncedSearch, page, PAGE_SIZE,
         Object.keys(filters).length > 0 ? filters as Parameters<typeof listingService.getAll>[4] : undefined);
       setData(result);
+      setLastRefreshAt(new Date());
     } catch {
-      toast.error('Greska pri ucitavanju hartija od vrednosti');
+      if (!opts?.silent) toast.error('Greska pri ucitavanju hartija od vrednosti');
       setData({ content: [], totalPages: 0, totalElements: 0, number: 0, size: PAGE_SIZE } as PaginatedResponse<Listing>);
     } finally {
-      setLoading(false);
+      if (!opts?.silent) setLoading(false);
     }
   }, [activeTab, debouncedSearch, debouncedFilters, page, priceRangeError]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
+
+  // Spec Sc 17 (Bug T4-005): auto-refresh svakih 30s bez korisnicke akcije.
+  // Skipuje refresh kad je 3D globe view aktivan (drugacija stranica) i kad
+  // je tab promenjen (fetchData ce sam odraditi).
+  useEffect(() => {
+    if (showGlobe) return;
+    const interval = setInterval(() => {
+      fetchData({ silent: true });
+    }, AUTO_REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [fetchData, showGlobe, AUTO_REFRESH_MS]);
+
+  // Formatirana relativna vremenska oznaka poslednjeg osvezavanja
+  const lastRefreshLabel = useMemo(() => {
+    if (!lastRefreshAt) return null;
+    return lastRefreshAt.toLocaleTimeString('sr-RS', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }, [lastRefreshAt]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -228,7 +263,8 @@ export default function SecuritiesListPage() {
       toast.error('Greska pri osvezavanju cena. Pokusajte ponovo.');
     } finally {
       setRefreshing(false);
-      fetchData();
+      await fetchData();
+      // fetchData je vec postavio lastRefreshAt; ovde nista dodatno.
     }
   };
 
@@ -328,6 +364,17 @@ export default function SecuritiesListPage() {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {/* Spec Sc 16 (Bug T4-004): "prikazuje se novo vreme poslednjeg osvezavanja" */}
+          {lastRefreshLabel && (
+            <span
+              className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono"
+              title="Vreme poslednjeg osvezavanja"
+              data-testid="securities-last-refresh"
+            >
+              <Clock className="h-3 w-3" />
+              Poslednje osvezeno: {lastRefreshLabel}
+            </span>
+          )}
           <Button
             variant={showFilters ? 'secondary' : 'outline'}
             size="sm"
@@ -344,6 +391,7 @@ export default function SecuritiesListPage() {
               onClick={handleRefresh}
               disabled={refreshing}
               className="gap-2"
+              data-testid="securities-refresh-btn"
             >
               <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
               Osvezi cene
@@ -472,8 +520,24 @@ export default function SecuritiesListPage() {
               placeholder="Pretrazi po ticker-u ili nazivu..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-10 bg-muted/30 dark:bg-slate-800/40 border-border/50"
+              className="pl-10 pr-10 bg-muted/30 dark:bg-slate-800/40 border-border/50"
+              data-testid="securities-search-input"
             />
+            {/* Spec Sc 13 (Bug T4-003 prijavljen 12.05.2026): "Obrisi pretragu"
+                dugme kad search ima sadrzaj. Klik resetuje filter i prikazuje
+                celokupnu listu. */}
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch('')}
+                title="Obrisi pretragu"
+                aria-label="Obrisi pretragu"
+                data-testid="securities-clear-search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -41,4 +41,23 @@ export const authService = {
   activateAccount: async (data: ActivateAccountRequest): Promise<void> => {
     await api.post('/auth-employee/activate', data);
   },
+
+  /**
+   * Spec Sc 9 + ad-hoc bug 12.05.2026: pre nego sto FE renderuje formu za
+   * aktivaciju, proveri stanje tokena. BE vraca VALID / USED / EXPIRED /
+   * INVALID / ALREADY_ACTIVE i FE prikazuje odgovarajucu poruku.
+   * Endpoint je javan (bez Authorization header-a).
+   */
+  getActivationTokenStatus: async (token: string): Promise<{
+    status: 'VALID' | 'USED' | 'EXPIRED' | 'INVALID' | 'ALREADY_ACTIVE';
+    expiresAt: string | null;
+    email: string | null;
+  }> => {
+    const response = await api.get<{
+      status: 'VALID' | 'USED' | 'EXPIRED' | 'INVALID' | 'ALREADY_ACTIVE';
+      expiresAt: string | null;
+      email: string | null;
+    }>(`/auth-employee/activation-token/${encodeURIComponent(token)}/status`);
+    return response.data;
+  },
 };

--- a/src/services/savingsService.ts
+++ b/src/services/savingsService.ts
@@ -1,0 +1,74 @@
+import api from './api';
+import type {
+  SavingsDepositDto,
+  SavingsTransactionDto,
+  SavingsRateDto,
+  OpenDepositRequest,
+  ToggleAutoRenewRequest,
+  WithdrawEarlyRequest,
+  UpsertRateRequest,
+  PageDto,
+} from '../types/savings';
+
+interface AdminListParams {
+  status?: string;
+  clientId?: number;
+  page?: number;
+  size?: number;
+}
+
+export const savingsService = {
+  openDeposit: async (dto: OpenDepositRequest): Promise<SavingsDepositDto> => {
+    const { data } = await api.post<SavingsDepositDto>('/savings/deposits', dto);
+    return data;
+  },
+
+  listMyDeposits: async (): Promise<SavingsDepositDto[]> => {
+    const { data } = await api.get<SavingsDepositDto[]>('/savings/deposits/my');
+    return data;
+  },
+
+  getDeposit: async (id: number): Promise<SavingsDepositDto> => {
+    const { data } = await api.get<SavingsDepositDto>(`/savings/deposits/${id}`);
+    return data;
+  },
+
+  getTransactions: async (id: number): Promise<SavingsTransactionDto[]> => {
+    const { data } = await api.get<SavingsTransactionDto[]>(`/savings/deposits/${id}/transactions`);
+    return data;
+  },
+
+  toggleAutoRenew: async (id: number, autoRenew: boolean): Promise<SavingsDepositDto> => {
+    const payload: ToggleAutoRenewRequest = { autoRenew };
+    const { data } = await api.patch<SavingsDepositDto>(`/savings/deposits/${id}/auto-renew`, payload);
+    return data;
+  },
+
+  withdrawEarly: async (id: number, otpCode: string): Promise<SavingsDepositDto> => {
+    const payload: WithdrawEarlyRequest = { otpCode };
+    const { data } = await api.post<SavingsDepositDto>(`/savings/deposits/${id}/withdraw-early`, payload);
+    return data;
+  },
+
+  getRates: async (currency?: string): Promise<SavingsRateDto[]> => {
+    const { data } = await api.get<SavingsRateDto[]>('/savings/rates', {
+      params: currency ? { currency } : {},
+    });
+    return data;
+  },
+
+  adminListAll: async (params: AdminListParams): Promise<PageDto<SavingsDepositDto>> => {
+    const { data } = await api.get<PageDto<SavingsDepositDto>>('/admin/savings/deposits', { params });
+    return data;
+  },
+
+  adminListAllRates: async (): Promise<SavingsRateDto[]> => {
+    const { data } = await api.get<SavingsRateDto[]>('/admin/savings/rates');
+    return data;
+  },
+
+  adminUpsertRate: async (dto: UpsertRateRequest): Promise<SavingsRateDto> => {
+    const { data } = await api.post<SavingsRateDto>('/admin/savings/rates', dto);
+    return data;
+  },
+};

--- a/src/types/celina2.ts
+++ b/src/types/celina2.ts
@@ -320,6 +320,10 @@ export interface CreateAccountRequest {
   currency: Currency;
   initialDeposit?: number;
   createCard?: boolean;          // Checkbox "Napravi karticu"
+  // Spec Celina 2 §454-455 + Bug T2-003 (12.05.2026): inicijalni limiti
+  // koje zaposleni moze podesiti pri kreiranju. Default-i 250k / 1M.
+  dailyLimit?: number;
+  monthlyLimit?: number;
   // Za poslovni racun - podaci o firmi
   companyName?: string;
   registrationNumber?: string;

--- a/src/types/savings.ts
+++ b/src/types/savings.ts
@@ -1,0 +1,111 @@
+export type SavingsDepositStatus = 'ACTIVE' | 'MATURED' | 'WITHDRAWN_EARLY' | 'RENEWED';
+
+export type SavingsTransactionType =
+  | 'OPEN'
+  | 'INTEREST_PAYMENT'
+  | 'PRINCIPAL_RETURN'
+  | 'EARLY_WITHDRAWAL_PRINCIPAL'
+  | 'EARLY_WITHDRAWAL_PENALTY'
+  | 'RENEWAL_OPEN';
+
+export interface SavingsDepositDto {
+  id: number;
+  clientId: number;
+  clientName: string;
+  linkedAccountId: number;
+  linkedAccountNumber: string;
+  principalAmount: number;
+  currencyCode: string;
+  termMonths: number;
+  annualInterestRate: number;
+  startDate: string;
+  maturityDate: string;
+  nextInterestPaymentDate: string;
+  totalInterestPaid: number;
+  autoRenew: boolean;
+  status: SavingsDepositStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SavingsTransactionDto {
+  id: number;
+  depositId: number;
+  type: SavingsTransactionType;
+  amount: number;
+  currencyCode: string;
+  processedDate: string;
+  resultingTransactionId: number | null;
+  description: string;
+  createdAt: string;
+}
+
+export interface SavingsRateDto {
+  id: number;
+  currencyCode: string;
+  termMonths: number;
+  annualRate: number;
+  active: boolean;
+  effectiveFrom: string;
+}
+
+export interface OpenDepositRequest {
+  sourceAccountId: number;
+  linkedAccountId: number;
+  principalAmount: number;
+  termMonths: number;
+  autoRenew: boolean;
+  otpCode: string;
+}
+
+export interface ToggleAutoRenewRequest {
+  autoRenew: boolean;
+}
+
+export interface WithdrawEarlyRequest {
+  otpCode: string;
+}
+
+export interface UpsertRateRequest {
+  currencyCode: string;
+  termMonths: number;
+  annualRate: number;
+}
+
+export interface PageDto<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
+export const MIN_DEPOSIT_AMOUNT: Record<string, number> = {
+  RSD: 10000,
+  JPY: 10000,
+  EUR: 100,
+  USD: 100,
+  CHF: 100,
+  GBP: 100,
+  CAD: 100,
+  AUD: 100,
+};
+
+export const TERM_OPTIONS = [3, 6, 12, 24, 36] as const;
+export type TermOption = (typeof TERM_OPTIONS)[number];
+
+export const STATUS_LABEL_SR: Record<SavingsDepositStatus, string> = {
+  ACTIVE: 'Aktivan',
+  MATURED: 'Dospelo',
+  WITHDRAWN_EARLY: 'Raskinuto',
+  RENEWED: 'Auto-obnovljen',
+};
+
+export const TRANSACTION_TYPE_LABEL_SR: Record<SavingsTransactionType, string> = {
+  OPEN: 'Otvaranje',
+  INTEREST_PAYMENT: 'Mesecna kamata',
+  PRINCIPAL_RETURN: 'Glavnica vracena',
+  EARLY_WITHDRAWAL_PRINCIPAL: 'Raskid — glavnica',
+  EARLY_WITHDRAWAL_PENALTY: 'Penal raskida',
+  RENEWAL_OPEN: 'Auto-obnova',
+};

--- a/src/utils/validationSchemas.celina2.test.ts
+++ b/src/utils/validationSchemas.celina2.test.ts
@@ -298,28 +298,34 @@ describe('REPAYMENT_PERIODS', () => {
 });
 
 describe('createAccountSchema', () => {
-  const validTekuci = {
+  // Spec Celina 2 §41-42 + Bug T2-001/T2-002 (12.05.2026): "Tip vlasnistva"
+  // (LICNI/POSLOVNI) i "Tip racuna" (TEKUCI/DEVIZNI) su DVA ORTOGONALNA polja.
+  // Pre 12.05.2026 jedan dropdown je mesao oba u TEKUCI/DEVIZNI/POSLOVNI sto
+  // je onemogucavalo kombinaciju "Poslovni + Devizni". Sad imamo odvojena polja.
+  const validLicniTekuci = {
     ownerEmail: 'test@banka.rs',
+    ownershipType: 'LICNI' as const,
     accountType: 'TEKUCI' as const,
     accountSubtype: 'STANDARDNI',
     currency: 'RSD',
   };
 
-  it('accepts valid TEKUCI account', () => {
-    expect(createAccountSchema.safeParse(validTekuci).success).toBe(true);
+  it('accepts valid LICNI + TEKUCI account', () => {
+    expect(createAccountSchema.safeParse(validLicniTekuci).success).toBe(true);
   });
 
   it('rejects TEKUCI with non-RSD currency', () => {
-    expect(createAccountSchema.safeParse({ ...validTekuci, currency: 'EUR' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, currency: 'EUR' }).success).toBe(false);
   });
 
-  it('rejects TEKUCI with business subtype', () => {
-    expect(createAccountSchema.safeParse({ ...validTekuci, accountSubtype: 'DOO' }).success).toBe(false);
+  it('rejects LICNI with business subtype (DOO)', () => {
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, accountSubtype: 'DOO' }).success).toBe(false);
   });
 
-  it('accepts valid DEVIZNI account', () => {
+  it('accepts valid LICNI + DEVIZNI account', () => {
     expect(createAccountSchema.safeParse({
       ownerEmail: 'test@banka.rs',
+      ownershipType: 'LICNI',
       accountType: 'DEVIZNI',
       accountSubtype: 'STANDARDNI',
       currency: 'EUR',
@@ -329,24 +335,27 @@ describe('createAccountSchema', () => {
   it('rejects DEVIZNI with RSD currency', () => {
     expect(createAccountSchema.safeParse({
       ownerEmail: 'test@banka.rs',
+      ownershipType: 'LICNI',
       accountType: 'DEVIZNI',
       accountSubtype: 'STANDARDNI',
       currency: 'RSD',
     }).success).toBe(false);
   });
 
-  it('rejects DEVIZNI with business subtype', () => {
+  it('rejects LICNI + DEVIZNI with business subtype', () => {
     expect(createAccountSchema.safeParse({
       ownerEmail: 'test@banka.rs',
+      ownershipType: 'LICNI',
       accountType: 'DEVIZNI',
       accountSubtype: 'DOO',
       currency: 'EUR',
     }).success).toBe(false);
   });
 
-  const validPoslovni = {
+  const validPoslovniTekuci = {
     ownerEmail: 'firma@banka.rs',
-    accountType: 'POSLOVNI' as const,
+    ownershipType: 'POSLOVNI' as const,
+    accountType: 'TEKUCI' as const,
     accountSubtype: 'DOO',
     currency: 'RSD',
     companyName: 'Test DOO',
@@ -358,58 +367,82 @@ describe('createAccountSchema', () => {
     firmCountry: 'Srbija',
   };
 
-  it('accepts valid POSLOVNI account', () => {
-    expect(createAccountSchema.safeParse(validPoslovni).success).toBe(true);
+  it('accepts valid POSLOVNI + TEKUCI account', () => {
+    expect(createAccountSchema.safeParse(validPoslovniTekuci).success).toBe(true);
+  });
+
+  // Spec §41-42: ortogonalna kombinacija Poslovni + Devizni mora biti dozvoljena.
+  // Pre fix-a 12.05.2026 nije bila moguca jer je accountType bio jedan dropdown.
+  it('accepts valid POSLOVNI + DEVIZNI account (T2-002 fix)', () => {
+    expect(createAccountSchema.safeParse({
+      ...validPoslovniTekuci,
+      accountType: 'DEVIZNI',
+      currency: 'EUR',
+    }).success).toBe(true);
   });
 
   it('rejects POSLOVNI without companyName', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, companyName: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, companyName: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without registrationNumber', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, registrationNumber: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, registrationNumber: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without taxId', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, taxId: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, taxId: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without activityCode', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, activityCode: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, activityCode: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI with invalid activityCode format', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, activityCode: '6201' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, activityCode: '6201' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without firmAddress', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, firmAddress: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, firmAddress: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without firmCity', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, firmCity: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, firmCity: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI without firmCountry', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, firmCountry: '' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, firmCountry: '' }).success).toBe(false);
   });
 
   it('rejects POSLOVNI with personal subtype', () => {
-    expect(createAccountSchema.safeParse({ ...validPoslovni, accountSubtype: 'STANDARDNI' }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validPoslovniTekuci, accountSubtype: 'STANDARDNI' }).success).toBe(false);
   });
 
   it('accepts optional initialDeposit', () => {
-    expect(createAccountSchema.safeParse({ ...validTekuci, initialDeposit: 5000 }).success).toBe(true);
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, initialDeposit: 5000 }).success).toBe(true);
   });
 
   it('rejects negative initialDeposit', () => {
-    expect(createAccountSchema.safeParse({ ...validTekuci, initialDeposit: -100 }).success).toBe(false);
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, initialDeposit: -100 }).success).toBe(false);
+  });
+
+  // Bug T2-003 (12.05.2026): polja za dnevni i mesecni limit.
+  it('accepts optional dailyLimit and monthlyLimit', () => {
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, dailyLimit: 250000, monthlyLimit: 1000000 }).success).toBe(true);
+  });
+
+  it('rejects negative dailyLimit', () => {
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, dailyLimit: -100 }).success).toBe(false);
+  });
+
+  it('rejects dailyLimit greater than monthlyLimit', () => {
+    expect(createAccountSchema.safeParse({ ...validLicniTekuci, dailyLimit: 2_000_000, monthlyLimit: 1_000_000 }).success).toBe(false);
   });
 
   it('accepts DEVIZNI with all foreign currencies', () => {
     for (const cur of ['EUR', 'CHF', 'USD', 'GBP', 'JPY', 'CAD', 'AUD']) {
       expect(createAccountSchema.safeParse({
         ownerEmail: 'test@banka.rs',
+        ownershipType: 'LICNI',
         accountType: 'DEVIZNI',
         accountSubtype: 'STANDARDNI',
         currency: cur,
@@ -417,9 +450,9 @@ describe('createAccountSchema', () => {
     }
   });
 
-  it('accepts all personal subtypes for TEKUCI', () => {
+  it('accepts all personal subtypes for LICNI + TEKUCI', () => {
     for (const sub of ['STANDARDNI', 'STEDNI', 'PENZIONERSKI', 'ZA_MLADE', 'STUDENTSKI', 'ZA_NEZAPOSLENE']) {
-      expect(createAccountSchema.safeParse({ ...validTekuci, accountSubtype: sub }).success).toBe(true);
+      expect(createAccountSchema.safeParse({ ...validLicniTekuci, accountSubtype: sub }).success).toBe(true);
     }
   });
 });

--- a/src/utils/validationSchemas.celina2.ts
+++ b/src/utils/validationSchemas.celina2.ts
@@ -148,13 +148,24 @@ const personalSubtypes = ['STANDARDNI', 'STEDNI', 'PENZIONERSKI', 'ZA_MLADE', 'S
 const businessSubtypes = ['DOO', 'AD', 'FONDACIJA'];
 const foreignCurrencies = ['EUR', 'CHF', 'USD', 'GBP', 'JPY', 'CAD', 'AUD'];
 
+// Spec Celina 2 §41-42 + Bug T2-001/T2-002 (prijavljen 12.05.2026):
+// Tip vlasnistva (LICNI/POSLOVNI) i Tip racuna (TEKUCI/DEVIZNI) su
+// DVA ORTOGONALNA KONCEPTA. Pre fix-a forma je mesala oba u jedan
+// dropdown sa vrednostima TEKUCI/DEVIZNI/POSLOVNI, sto je
+// onemogucavalo kombinaciju (npr. Poslovni + Devizni). Sad imamo
+// odvojena polja.
 export const createAccountSchema = z
   .object({
     ownerEmail: emailSchema,
-    accountType: z.enum(['TEKUCI', 'DEVIZNI', 'POSLOVNI'], { message: 'Izaberite tip racuna' }),
+    ownershipType: z.enum(['LICNI', 'POSLOVNI'], { message: 'Izaberite tip vlasnistva' }),
+    accountType: z.enum(['TEKUCI', 'DEVIZNI'], { message: 'Izaberite tip racuna' }),
     accountSubtype: z.string().min(1, 'Izaberite podvrstu racuna'),
     currency: z.string().min(1, 'Izaberite valutu'),
     initialDeposit: z.number().min(0, 'Depozit ne moze biti negativan').max(999999999999.99, 'Depozit prelazi maksimalnu dozvoljenu vrednost').optional(),
+    // Bug T2-003: Plan_Manuelnog_Testiranja.pdf trazi polje za limite pri
+    // kreiranju. Default-i (250k dnevni / 1M mesecni) iz Celina 2 tabele.
+    dailyLimit: z.number().min(0, 'Limit ne moze biti negativan').optional(),
+    monthlyLimit: z.number().min(0, 'Limit ne moze biti negativan').optional(),
     createCard: z.boolean().optional(),
     // Polja za poslovni racun - firma
     companyName: z.string().optional(),
@@ -170,28 +181,27 @@ export const createAccountSchema = z
     firmCountry: z.string().optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.accountType === 'TEKUCI') {
-      if (!personalSubtypes.includes(data.accountSubtype)) {
-        ctx.addIssue({ code: 'custom', path: ['accountSubtype'], message: 'Neispravna podvrsta za tekuci racun' });
-      }
-      if (data.currency !== 'RSD') {
-        ctx.addIssue({ code: 'custom', path: ['currency'], message: 'Tekuci racun moze biti samo u RSD valuti' });
-      }
+    // Validacija podvrste i valute na osnovu kombinacije ownershipType x accountType.
+    const isLicni = data.ownershipType === 'LICNI';
+    const isPoslovni = data.ownershipType === 'POSLOVNI';
+    const isTekuci = data.accountType === 'TEKUCI';
+    const isDevizni = data.accountType === 'DEVIZNI';
+
+    if (isLicni && !personalSubtypes.includes(data.accountSubtype)) {
+      ctx.addIssue({ code: 'custom', path: ['accountSubtype'], message: 'Neispravna podvrsta za licni racun' });
+    }
+    if (isPoslovni && !businessSubtypes.includes(data.accountSubtype)) {
+      ctx.addIssue({ code: 'custom', path: ['accountSubtype'], message: 'Neispravna podvrsta za poslovni racun' });
     }
 
-    if (data.accountType === 'DEVIZNI') {
-      if (!personalSubtypes.includes(data.accountSubtype)) {
-        ctx.addIssue({ code: 'custom', path: ['accountSubtype'], message: 'Neispravna podvrsta za devizni racun' });
-      }
-      if (!foreignCurrencies.includes(data.currency)) {
-        ctx.addIssue({ code: 'custom', path: ['currency'], message: 'Devizni racun podrzava samo strane valute' });
-      }
+    if (isTekuci && data.currency !== 'RSD') {
+      ctx.addIssue({ code: 'custom', path: ['currency'], message: 'Tekuci racun moze biti samo u RSD valuti' });
+    }
+    if (isDevizni && !foreignCurrencies.includes(data.currency)) {
+      ctx.addIssue({ code: 'custom', path: ['currency'], message: 'Devizni racun podrzava samo strane valute' });
     }
 
-    if (data.accountType === 'POSLOVNI') {
-      if (!businessSubtypes.includes(data.accountSubtype)) {
-        ctx.addIssue({ code: 'custom', path: ['accountSubtype'], message: 'Neispravna podvrsta za poslovni racun' });
-      }
+    if (isPoslovni) {
       if (!data.companyName?.trim()) {
         ctx.addIssue({ code: 'custom', path: ['companyName'], message: 'Naziv firme je obavezan' });
       }
@@ -213,6 +223,10 @@ export const createAccountSchema = z
       if (!data.firmCountry?.trim()) {
         ctx.addIssue({ code: 'custom', path: ['firmCountry'], message: 'Drzava firme je obavezna' });
       }
+    }
+
+    if (data.dailyLimit != null && data.monthlyLimit != null && data.dailyLimit > data.monthlyLimit) {
+      ctx.addIssue({ code: 'custom', path: ['dailyLimit'], message: 'Dnevni limit ne moze biti veci od mesecnog limita' });
     }
   });
 export type CreateAccountFormData = z.infer<typeof createAccountSchema>;


### PR DESCRIPTION
## Summary

Dva paralelna scope-a u jednoj grani:

### 1. Stedna knjizica (oroceni depozit) — 12.05.2026 jutro

Nov klijent feature: oroceni depozit (3/6/12/24/36 meseci) sa pun lifecycle-om kroz FE.

- **5 stranica**: `SavingsListPage` (hero sa 4 KPI), `SavingsNewDepositPage` (zod + live SavingsCalculator widget), `SavingsDetailsPage` (timeline + auto-renew Switch + raskini ranije), `AdminSavingsDepositsPage` (paginated), `AdminSavingsRatesPage` (grid + edit dialog).
- **Wiring**: 5 ruta u App.tsx (`noAgentOnly` + `supervisorOnly` + `adminOnly` guards), `ClientSidebar` PiggyBank link + Vault/Percent admin sekcija, HomePage 5. KPI chip "Orocno" sa FX→RSD.
- **Servisi + tipovi**: `savingsService` (11 wrappera), `types/savings.ts`, `SavingsCalculator` reusable komponent, `VerificationModal` reuse.
- **Testovi**: 18 vitest testova PASS (service 11 + Calculator 4 + ListPage 3).

### 2. Bug fix runda — 12.05.2026 vece

8 FE bagova iz 3 xlsx tracker-a + ad-hoc Sc 9 Tim 1.

**Auth (3)**: LoginPage password clear (T1-013), lockout prefix-detekcija SR + EN (T1-017), ActivateAccountPage kompletan refaktor sa pre-check tokena (Sc 9).

**Employee (2)**: EmployeeEditPage email disabled + aria-readonly (T1-009), EmployeeListPage row-level PowerOff/Power dugme + Radix confirm dialog (T1-011).

**Account creation (3)**: CreateAccountPage razdvojen ownershipType (LICNI/POSLOVNI) od accountType (TEKUCI/DEVIZNI) (T2-001/T2-002), Daily/Monthly limit polja sa zod cross-validacijom (T2-003).

**Aktuari (1)**: ActuaryManagementPage filter po poziciji (T4-001).

**Securities (3)**: SecuritiesListPage clear search X dugme (T4-003), Last refresh timestamp (T4-004), auto-refresh 30s (T4-005).

**Payment (1)**: NewPaymentPage confirm dialog pre OTP-a sa FX/inter-bank napomenama (T2-005).

### 3. Savings TS build fix (otkriveno 12.05 vece pri Docker rebuild-u)

Pre fix-a, savings runda jutros prosla `vitest` ali NE `npm run build` (tsc -b):
- `AdminSavingsDepositsPage` + `AdminSavingsRatesPage`: type-only imports (verbatimModuleSyntax TS1484)
- `SavingsNewDepositPage`: `Account.currency` je string union "RSD"/"EUR"/... NE objekat sa `.code` (TS2339, 3 mesta)

Posle fix-a: `npm run build` PASS, FE Docker image rebuilt sa savings JS chunkovima u bundle-u.

## Test plan

- [x] `npx vitest run` → **1538/1538 PASS**
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npm run build` → built in 930ms (vendor 2.27MB / gzip 638KB)
- [x] `npx eslint .` → 0 errors, 76 pre-existing warnings (React Compiler diagnostics dokumentovani)
- [x] Docker rebuild --no-cache + verifikovano da `index-*.js` u bundle-u sadrzi PiggyBank + Stednja stringove
- [x] Live smoke: Stefan login preko proxy (200), `GET /api/savings/deposits/my` (200, 1 deposit), `GET /api/savings/rates?currency=RSD` (200, 5 stopa)