### PR TITLE
feat(fe): FE4 7.1 — istorija dividendi po poziciji u portfoliju

### DIFF
--- a/cypress/e2e/celina3-mock.cy.ts
+++ b/cypress/e2e/celina3-mock.cy.ts
@@ -803,6 +803,60 @@ describe('Feature: Moj portfolio', () => {
 });
 
 // ====================================================================
+// SECTION 6b: Istorija dividendi u portfoliju (FE4 — zadatak 7.1)
+// ====================================================================
+
+describe('Feature: Istorija dividendi u portfoliju (FE4 7.1)', () => {
+  const mockDividends = [
+    {
+      id: 1, ownerId: 1, ownerType: 'CLIENT', stockListingId: 1, stockTicker: 'MSFT',
+      quantity: 25, priceOnDate: 420.50, dividendYieldRate: 0.0018,
+      grossAmount: 18.92, tax: 2.84, netAmount: 16.08, creditedAccountId: 100,
+      currencyCode: 'USD', paymentDate: '2026-03-31', taxExempt: false,
+      createdAt: '2026-03-31T17:00:00',
+    },
+  ];
+
+  beforeEach(() => {
+    setupMocks();
+    cy.intercept('GET', '**/api/portfolio/my', { statusCode: 200, body: mockPortfolio });
+    cy.intercept('GET', '**/api/portfolio/summary', { statusCode: 200, body: mockPortfolioSummary });
+  });
+
+  it('FE4-D1: STOCK pozicija ima dugme za razvijanje istorije dividendi', () => {
+    cy.intercept('GET', '**/api/dividends/by-position/*', { statusCode: 200, body: [] });
+    cy.visit('/portfolio', { onBeforeLoad: setupClientSession });
+    cy.get('[data-testid="dividend-toggle-1"]').should('exist');
+  });
+
+  it('FE4-D2: Razvijanje pozicije prikazuje istoriju primljenih dividendi', () => {
+    cy.intercept('GET', '**/api/dividends/by-position/1', {
+      statusCode: 200,
+      body: mockDividends,
+    }).as('divs');
+    cy.visit('/portfolio', { onBeforeLoad: setupClientSession });
+    cy.get('[data-testid="dividend-toggle-1"]').click();
+    cy.wait('@divs');
+    cy.get('[data-testid="dividend-history-table"]').should('be.visible');
+    cy.contains('Istorija primljenih dividendi').should('be.visible');
+  });
+
+  it('FE4-D3: Pozicija bez dividendi prikazuje prazno stanje', () => {
+    cy.intercept('GET', '**/api/dividends/by-position/*', { statusCode: 200, body: [] });
+    cy.visit('/portfolio', { onBeforeLoad: setupClientSession });
+    cy.get('[data-testid="dividend-toggle-1"]').click();
+    cy.get('[data-testid="dividend-history-empty"]').should('be.visible');
+  });
+
+  it('FE4-D4: 404 sa BE prikazuje poruku da endpoint nije dostupan', () => {
+    cy.intercept('GET', '**/api/dividends/by-position/*', { statusCode: 404, body: {} });
+    cy.visit('/portfolio', { onBeforeLoad: setupClientSession });
+    cy.get('[data-testid="dividend-toggle-1"]').click();
+    cy.get('[data-testid="dividend-history-unavailable"]').should('be.visible');
+  });
+});
+
+// ====================================================================
 // SECTION 7: Porez tracking (S74-S81)
 // ====================================================================
 

--- a/src/pages/Portfolio/PortfolioPage.test.tsx
+++ b/src/pages/Portfolio/PortfolioPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PortfolioPage from './PortfolioPage';
 import { renderWithProviders } from '../../test/test-utils';
@@ -370,5 +370,42 @@ describe('PortfolioPage', () => {
 
     // Drugi klik (collapse) ne sme da pravi novi BE poziv — rezultat je keširan.
     expect(mockGetDividendsByPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error message when dividend endpoint fails with a non-404 error', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockRejectedValue({ response: { status: 500 } });
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-error')).toBeInTheDocument();
+    });
+  });
+
+  it('renders em-dash for tax on a tax-exempt (EMPLOYEE) dividend', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockResolvedValue([
+      { ...mockDividend, id: 9, taxExempt: true, tax: 0 },
+    ]);
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-table')).toBeInTheDocument();
+    });
+    // Tax-exempt red prikazuje '—' umesto iznosa poreza.
+    const table = screen.getByTestId('dividend-history-table');
+    expect(within(table).getByText('—')).toBeInTheDocument();
   });
 });

--- a/src/pages/Portfolio/PortfolioPage.test.tsx
+++ b/src/pages/Portfolio/PortfolioPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import PortfolioPage from './PortfolioPage';
 import { renderWithProviders } from '../../test/test-utils';
 import type { PortfolioItem, PortfolioSummary } from '@/types/celina3';
+import type { DividendPayoutDto } from '@/types/dividend';
 
 const mockNavigate = vi.fn();
 
@@ -53,9 +54,29 @@ const mockItems: PortfolioItem[] = [
   },
 ];
 
+const mockDividend: DividendPayoutDto = {
+  id: 1,
+  ownerId: 42,
+  ownerType: 'CLIENT',
+  stockListingId: 1,
+  stockTicker: 'AAPL',
+  quantity: 50,
+  priceOnDate: 178.5,
+  dividendYieldRate: 0.005,
+  grossAmount: 50,
+  tax: 7.5,
+  netAmount: 42.5,
+  creditedAccountId: 265,
+  currencyCode: 'USD',
+  paymentDate: '2026-03-31',
+  taxExempt: false,
+  createdAt: '2026-03-31T17:00:00Z',
+};
+
 const mockGetSummary = vi.fn().mockResolvedValue(mockSummary);
 const mockGetMyPortfolio = vi.fn().mockResolvedValue(mockItems);
 const mockSetPublicQuantity = vi.fn().mockResolvedValue({ ...mockItems[0], publicQuantity: 20 });
+const mockGetDividendsByPosition = vi.fn();
 
 vi.mock('../../services/portfolioService', () => ({
   default: {
@@ -68,6 +89,13 @@ vi.mock('../../services/portfolioService', () => ({
 vi.mock('../../services/listingService', () => ({
   default: {
     exerciseOption: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../services/dividendService', () => ({
+  default: {
+    getMyDividends: vi.fn(),
+    getDividendsByPosition: (...args: unknown[]) => mockGetDividendsByPosition(...args),
   },
 }));
 
@@ -95,6 +123,7 @@ describe('PortfolioPage', () => {
     vi.clearAllMocks();
     mockGetSummary.mockResolvedValue(mockSummary);
     mockGetMyPortfolio.mockResolvedValue(mockItems);
+    mockGetDividendsByPosition.mockResolvedValue([]);
   });
 
   it('renders the page header', async () => {
@@ -253,5 +282,93 @@ describe('PortfolioPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Moji fondovi' }));
     expect(screen.getByText('Mocked MyFundsTab Content')).toBeInTheDocument();
+  });
+
+  // --- FE4 (7.1) — istorija dividendi po poziciji ---
+
+  it('renders dividend history toggle only for STOCK positions', async () => {
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('AAPL')).toBeInTheDocument();
+    });
+
+    // AAPL je STOCK -> ima toggle; ES=F je FUTURES -> nema.
+    expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('dividend-toggle-2')).not.toBeInTheDocument();
+  });
+
+  it('expands dividend history and shows empty state when no dividends', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockResolvedValue([]);
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+
+    expect(mockGetDividendsByPosition).toHaveBeenCalledWith(1);
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('renders dividend payout rows when history exists', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockResolvedValue([mockDividend]);
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-table')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Istorija primljenih dividendi')).toBeInTheDocument();
+    expect(screen.getByText('USD')).toBeInTheDocument();
+  });
+
+  it('shows unavailable message when dividend endpoint is not implemented (404)', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockRejectedValue({ response: { status: 404 } });
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-unavailable')).toBeInTheDocument();
+    });
+  });
+
+  it('collapses dividend history on second toggle click', async () => {
+    const user = userEvent.setup();
+    mockGetDividendsByPosition.mockResolvedValue([]);
+    renderWithProviders(<PortfolioPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-toggle-1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('dividend-history-empty')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('dividend-toggle-1'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('dividend-history-empty')).not.toBeInTheDocument();
+    });
+
+    // Drugi klik (collapse) ne sme da pravi novi BE poziv — rezultat je keširan.
+    expect(mockGetDividendsByPosition).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/Portfolio/PortfolioPage.tsx
+++ b/src/pages/Portfolio/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { Component, useEffect, useState, useMemo, type ChangeEvent, type ReactNode } from 'react';
+import { Component, Fragment, useEffect, useState, useMemo, type ChangeEvent, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Briefcase,
@@ -8,6 +8,9 @@ import {
   Wallet,
   ArrowRightLeft,
   Zap,
+  ChevronDown,
+  ChevronRight,
+  Coins,
 } from 'lucide-react';
 import {
   PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend,
@@ -18,10 +21,12 @@ import type { PieLabelRenderProps } from 'recharts';
 import portfolioService from '@/services/portfolioService';
 import listingService from '@/services/listingService';
 import taxService from '@/services/taxService';
+import dividendService from '@/services/dividendService';
 import { useAuth } from '@/context/AuthContext';
 import { toast } from '@/lib/notify';
 import type { PortfolioItem, PortfolioSummary, TaxBreakdownItemDto } from '@/types/celina3';
-import { formatAmount, formatDateTime } from '@/utils/formatters';
+import type { DividendPayoutDto } from '@/types/dividend';
+import { formatAmount, formatDate, formatDateTime } from '@/utils/formatters';
 import { parseNumber } from '@/utils/numberUtils';
 
 import { Button } from '@/components/ui/button';
@@ -39,32 +44,122 @@ import {
 } from '@/components/ui/table';
 import MyFundsTab from '@/pages/Funds/MyFundsTab';
 
-/*
- * TODO [FE4 - Istorija dividendi | Developer: Jovan Krunic]
- *
- * Uz svaku STOCK poziciju u portfoliju prikazati istoriju primljenih dividendi:
- *
- *  1. Novi servis dividendService (src/services/dividendService.ts):
- *     - getDividendHistory(listingId): GET /portfolio/dividends?listingId=X
- *       vraca listu { date: string, amountGross: number, taxWithheld: number,
- *       amountNet: number, currency: string }.
- *     - getMyDividendSummary(): GET /portfolio/dividends/summary — ukupno primljeno
- *       po valuti (za KPI chip na vrhu stranice).
- *
- *  2. Prikaz po poziciji — jedna od sledecih opcija:
- *     (a) Nova kolona "Dividende" u tabeli hartija sa ukupnim iznosom i
- *         klikom koji razvija inlajn red sa historijom;
- *     (b) Poseban "Dividende" tab pored "Moje hartije" i "Moji fondovi";
- *     (c) Expand dugme po redu koje otvara Accordion sa listom isplata.
- *
- *  3. Svaki red istorije prikazuje: datum isplate, bruto iznos, porez po odbitku,
- *     neto iznos, valuta — sve formatirane kroz formatAmount + sr-RS locale.
- *
- *  4. Opcionalno: KPI chip "Ukupne dividende YTD" u summary kartici na vrhu
- *     (paritet sa Neto vrednost / ROI chipovima).
- *
- *  Tip podataka dodati u src/types/celina3.ts (DividendRecord interface).
+// ============================================================
+// FE4 (7.1) — Istorija dividendi u portfoliju (Developer: Jovan Krunic)
+// Uz svaku STOCK poziciju prikazuje se expand red sa istorijom primljenih
+// dividendi (datum isplate, bruto, porez, neto, valuta). Podaci se lazy-load-uju
+// sa B9 endpoint-a GET /dividends/by-position/{portfolioId} prvi put kad se
+// pozicija razvije; 404/501/405 se tretira kao "BE jos nije dostupan".
+// ============================================================
+
+type DividendLoadStatus = 'loading' | 'ready' | 'error' | 'unavailable';
+
+/**
+ * Inline panel sa istorijom primljenih dividendi za jednu STOCK poziciju —
+ * renderuje se kao expand red ispod reda hartije u tabeli portfolija.
  */
+function DividendHistoryPanel({
+  status,
+  rows,
+}: {
+  status: DividendLoadStatus | undefined;
+  rows: DividendPayoutDto[] | undefined;
+}) {
+  if (status === undefined || status === 'loading') {
+    return (
+      <div className="space-y-2 py-2" data-testid="dividend-history-loading">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-8 animate-pulse rounded bg-muted/50" />
+        ))}
+      </div>
+    );
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <Alert data-testid="dividend-history-unavailable">
+        <AlertDescription>
+          Istorija dividendi trenutno nije dostupna (BE endpoint nije implementiran).
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Alert variant="destructive" data-testid="dividend-history-error">
+        <AlertDescription>
+          Greška pri učitavanju istorije dividendi. Pokušajte ponovo kasnije.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!rows || rows.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center py-6 text-center"
+        data-testid="dividend-history-empty"
+      >
+        <Coins className="mb-2 h-6 w-6 text-muted-foreground" />
+        <p className="text-sm font-medium">Nema primljenih dividendi za ovu poziciju</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Kvartalne isplate dividendi će se prikazati ovde.
+        </p>
+      </div>
+    );
+  }
+
+  const totalNet = rows.reduce((sum, r) => sum + (Number(r.netAmount) || 0), 0);
+  const currency = rows[0]?.currencyCode ?? '';
+
+  return (
+    <div className="space-y-2 py-2" data-testid="dividend-history-table">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Coins className="h-4 w-4 text-amber-500" />
+        Istorija primljenih dividendi
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Datum isplate</TableHead>
+            <TableHead className="text-right">Količina</TableHead>
+            <TableHead className="text-right">Bruto</TableHead>
+            <TableHead className="text-right">Porez</TableHead>
+            <TableHead className="text-right">Neto</TableHead>
+            <TableHead>Valuta</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((r) => (
+            <TableRow key={r.id}>
+              <TableCell>{formatDate(r.paymentDate)}</TableCell>
+              <TableCell className="text-right font-mono">
+                {formatAmount(r.quantity, 0)}
+              </TableCell>
+              <TableCell className="text-right font-mono">
+                {formatAmount(r.grossAmount)}
+              </TableCell>
+              <TableCell className="text-right font-mono text-red-600 dark:text-red-400">
+                {r.taxExempt ? '—' : formatAmount(r.tax)}
+              </TableCell>
+              <TableCell className="text-right font-mono font-semibold text-emerald-600 dark:text-emerald-400">
+                {formatAmount(r.netAmount)}
+              </TableCell>
+              <TableCell className="text-muted-foreground">{r.currencyCode}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <p className="text-right text-xs text-muted-foreground">
+        Ukupno neto primljeno:{' '}
+        <span className="font-semibold text-foreground">
+          {formatAmount(totalNet)} {currency}
+        </span>
+      </p>
+    </div>
+  );
+}
 
 function formatPercent(value: number | null | undefined): string {
   const num = typeof value === 'number' ? value : parseNumber(value);
@@ -326,6 +421,12 @@ export default function PortfolioPage() {
   const [taxBreakdownLoading, setTaxBreakdownLoading] = useState(false);
   const [taxBreakdownError, setTaxBreakdownError] = useState<'unavailable' | 'error' | null>(null);
 
+  // FE4 (7.1) — istorija dividendi po STOCK poziciji. Lazy-loaded prvi put kad
+  // se pozicija razvije; rezultat se kesira po id-u pozicije.
+  const [expandedDividends, setExpandedDividends] = useState<number | null>(null);
+  const [dividendCache, setDividendCache] = useState<Record<number, DividendPayoutDto[]>>({});
+  const [dividendStatus, setDividendStatus] = useState<Record<number, DividendLoadStatus>>({});
+
   useEffect(() => {
     if (activeTab !== 'tax') return;
     if (taxBreakdown !== null) return; // vec ucitan
@@ -475,6 +576,34 @@ export default function PortfolioPage() {
     } finally {
       setExercisingId(null);
     }
+  };
+
+  // FE4 (7.1) — expand/collapse istorije dividendi za STOCK poziciju.
+  const toggleDividendHistory = (item: PortfolioItem) => {
+    const id = item.id;
+    if (expandedDividends === id) {
+      setExpandedDividends(null);
+      return;
+    }
+    setExpandedDividends(id);
+
+    // Lazy fetch — samo prvi put po poziciji; rezultat ostaje keširan.
+    if (dividendStatus[id]) return;
+    setDividendStatus((prev) => ({ ...prev, [id]: 'loading' }));
+    void dividendService
+      .getDividendsByPosition(id)
+      .then((rows) => {
+        setDividendCache((prev) => ({ ...prev, [id]: Array.isArray(rows) ? rows : [] }));
+        setDividendStatus((prev) => ({ ...prev, [id]: 'ready' }));
+      })
+      .catch((err: unknown) => {
+        const httpStatus = (err as { response?: { status?: number } })?.response?.status;
+        const next: DividendLoadStatus =
+          httpStatus === 404 || httpStatus === 501 || httpStatus === 405
+            ? 'unavailable'
+            : 'error';
+        setDividendStatus((prev) => ({ ...prev, [id]: next }));
+      });
   };
 
   const totalValue = summary?.totalValue ?? 0;
@@ -686,9 +815,11 @@ export default function PortfolioPage() {
                         : false;
                       const canExercise =
                         isOption && isEmployee && !isExpired && item.inTheMoney === true;
+                      const isDividendsOpen = expandedDividends === item.id;
 
                       return (
-                        <TableRow key={item.id}>
+                        <Fragment key={item.id}>
+                        <TableRow>
                           <TableCell>
                             <Badge variant={getListingTypeBadgeVariant(item.listingType)}>
                               {getListingTypeLabel(item.listingType)}
@@ -696,9 +827,29 @@ export default function PortfolioPage() {
                           </TableCell>
 
                           <TableCell className="font-medium">
-                            <div>{item.listingTicker}</div>
-                            <div className="text-xs text-muted-foreground">
-                              {item.listingName}
+                            <div className="flex items-center gap-1.5">
+                              {isStock && (
+                                <button
+                                  type="button"
+                                  onClick={() => toggleDividendHistory(item)}
+                                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                                  title="Istorija dividendi"
+                                  aria-expanded={isDividendsOpen}
+                                  data-testid={`dividend-toggle-${item.id}`}
+                                >
+                                  {isDividendsOpen ? (
+                                    <ChevronDown className="h-4 w-4" />
+                                  ) : (
+                                    <ChevronRight className="h-4 w-4" />
+                                  )}
+                                </button>
+                              )}
+                              <div>
+                                <div>{item.listingTicker}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {item.listingName}
+                                </div>
+                              </div>
                             </div>
                           </TableCell>
 
@@ -809,6 +960,17 @@ export default function PortfolioPage() {
                             </div>
                           </TableCell>
                         </TableRow>
+                        {isStock && isDividendsOpen && (
+                          <TableRow>
+                            <TableCell colSpan={11} className="bg-muted/20">
+                              <DividendHistoryPanel
+                                status={dividendStatus[item.id]}
+                                rows={dividendCache[item.id]}
+                              />
+                            </TableCell>
+                          </TableRow>
+                        )}
+                        </Fragment>
                       );
                     })}
                   </TableBody>

--- a/src/services/dividendService.test.ts
+++ b/src/services/dividendService.test.ts
@@ -1,39 +1,89 @@
-// ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
-//
-// Testovi za dividendService.
-//
-// IMPLEMENTIRATI (posle implementacije servisa):
-//   - Svaki test mockuje './api' default export sa vi.mock
-//   - vi.mocked(api.get).mockResolvedValue({ data: <stub> }) pattern
-//   - Posle svakog testa: vi.clearAllMocks()
-//
-// Planirani test slucajevi:
-//   1. 'getMyDividends — poziva GET /dividends/my bez params'
-//   2. 'getMyDividends — prosledjuje ticker, fromDate, toDate kao query params'
-//   3. 'getMyDividends — prosledjuje page i size kao query params'
-//   4. 'getMyDividends — vraca data iz axios odgovora'
-//   5. 'getDividendSummary — poziva GET /dividends/my/summary'
-//   6. 'getDividendSummary — vraca DividendSummaryDto iz odgovora'
-//   7. 'getDividendsByListing — poziva GET /dividends/listings/{listingId}'
-//   8. 'getDividendsByListing — prosledjuje fromDate i toDate kao query params'
-//   9. 'getDividendsByListing — vraca paginiranu listu iz odgovora'
-//  10. 'getMyDividends — baca gresku ako axios odbije (network error)'
-//  11. 'getDividendSummary — baca gresku ako axios vrati 403'
-// ============================================================
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { describe, it } from 'vitest';
+// Mockujem api modul pre dividend service import-a
+vi.mock('./api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import dividendService from './dividendService';
+import api from './api';
+import type { DividendPayoutDto } from '../types/dividend';
+
+const mockGet = api.get as ReturnType<typeof vi.fn>;
+
+const sampleDividend: DividendPayoutDto = {
+  id: 1,
+  ownerId: 42,
+  ownerType: 'CLIENT',
+  stockListingId: 7,
+  stockTicker: 'AAPL',
+  quantity: 50,
+  priceOnDate: 200,
+  dividendYieldRate: 0.005,
+  grossAmount: 50,
+  tax: 7.5,
+  netAmount: 42.5,
+  creditedAccountId: 265,
+  currencyCode: 'USD',
+  paymentDate: '2026-03-31',
+  taxExempt: false,
+  createdAt: '2026-03-31T17:00:00',
+};
 
 describe('dividendService', () => {
-  it.todo('getMyDividends — poziva GET /dividends/my bez params');
-  it.todo('getMyDividends — prosledjuje ticker, fromDate, toDate kao query params');
-  it.todo('getMyDividends — prosledjuje page i size kao query params');
-  it.todo('getMyDividends — vraca data iz axios odgovora');
-  it.todo('getDividendSummary — poziva GET /dividends/my/summary');
-  it.todo('getDividendSummary — vraca DividendSummaryDto iz odgovora');
-  it.todo('getDividendsByListing — poziva GET /dividends/listings/{listingId}');
-  it.todo('getDividendsByListing — prosledjuje fromDate i toDate kao query params');
-  it.todo('getDividendsByListing — vraca paginiranu listu iz odgovora');
-  it.todo('getMyDividends — baca gresku ako axios odbije (network error)');
-  it.todo('getDividendSummary — baca gresku ako axios vrati 403');
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getMyDividends', () => {
+    it('salje GET /dividends/my', async () => {
+      mockGet.mockResolvedValue({ data: [] });
+
+      await dividendService.getMyDividends();
+
+      expect(mockGet).toHaveBeenCalledWith('/dividends/my');
+    });
+
+    it('vraca listu dividendi iz BE odgovora', async () => {
+      mockGet.mockResolvedValue({ data: [sampleDividend] });
+
+      const result = await dividendService.getMyDividends();
+
+      expect(result).toEqual([sampleDividend]);
+    });
+
+    it('propagira gresku ako api odbije zahtev', async () => {
+      mockGet.mockRejectedValue(new Error('network error'));
+
+      await expect(dividendService.getMyDividends()).rejects.toThrow('network error');
+    });
+  });
+
+  describe('getDividendsByPosition', () => {
+    it('salje GET /dividends/by-position/{portfolioId}', async () => {
+      mockGet.mockResolvedValue({ data: [] });
+
+      await dividendService.getDividendsByPosition(99);
+
+      expect(mockGet).toHaveBeenCalledWith('/dividends/by-position/99');
+    });
+
+    it('vraca istoriju dividendi za poziciju iz BE odgovora', async () => {
+      mockGet.mockResolvedValue({ data: [sampleDividend] });
+
+      const result = await dividendService.getDividendsByPosition(7);
+
+      expect(result).toEqual([sampleDividend]);
+    });
+
+    it('propagira gresku ako api odbije zahtev', async () => {
+      mockGet.mockRejectedValue(new Error('403 forbidden'));
+
+      await expect(dividendService.getDividendsByPosition(7)).rejects.toThrow(
+        '403 forbidden',
+      );
+    });
+  });
 });

--- a/src/services/dividendService.ts
+++ b/src/services/dividendService.ts
@@ -1,30 +1,32 @@
-// ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
-//
-// HTTP wrapper za dividendne endpoint-e. Sve metode koriste `api` klijent
-// iz './api' (axios instanca sa JWT interceptorom).
-//
-// IMPLEMENTIRATI (uvezi tipove iz '../types/dividend' kada ih definises):
-//   - getMyDividends(params: DividendFilterParams): Promise<PageDto<DividendPayoutDto>>
-//       GET /dividends/my
-//       Query params: ticker, fromDate, toDate, page, size
-//       Vraca paginiranu listu primljenih dividendi za prijavljenog klijenta.
-//
-//   - getDividendSummary(): Promise<DividendSummaryDto>
-//       GET /dividends/my/summary
-//       Vraca agregirane metrike: ukupno primljeno u RSD, po ticker-u, datum zadnje isplate.
-//
-//   - getDividendsByListing(listingId: number, params?: DividendFilterParams): Promise<PageDto<DividendPayoutDto>>
-//       GET /dividends/listings/{listingId}
-//       Vraca istoriju dividendi za specificnu hartiju (korisno za admin/supervisor pregled).
-//
-// Pattern:
-//   import api from './api';
-//   export const dividendService = { ... };
-//   Svaka metoda destrukturira { data } iz api.get/post poziva i vraca data.
-//
-// Konvencija: pratiti postojecu `Savings` feature celinu kao sablon.
-// Spec: Zadaci_Frontend.pdf, FE4.
-// ============================================================
+import api from './api';
+import type { DividendPayoutDto } from '../types/dividend';
 
-export {};
+/**
+ * Dividend API wrapper — odgovara `/dividends/**` endpoint-ima backend-a (B9).
+ *
+ * FE4, zadatak 7.1 — istorija primljenih dividendi po poziciji u portfoliju.
+ */
+const dividendService = {
+  /**
+   * Sve dividende ulogovanog korisnika (CLIENT ili EMPLOYEE),
+   * sortirane paymentDate DESC.
+   * BE endpoint: GET /dividends/my
+   */
+  getMyDividends: async (): Promise<DividendPayoutDto[]> => {
+    const { data } = await api.get<DividendPayoutDto[]>('/dividends/my');
+    return data;
+  },
+
+  /**
+   * Istorija dividendi za konkretnu poziciju u portfoliju.
+   * BE endpoint: GET /dividends/by-position/{portfolioId}
+   */
+  getDividendsByPosition: async (portfolioId: number): Promise<DividendPayoutDto[]> => {
+    const { data } = await api.get<DividendPayoutDto[]>(
+      `/dividends/by-position/${portfolioId}`,
+    );
+    return data;
+  },
+};
+
+export default dividendService;

--- a/src/types/dividend.ts
+++ b/src/types/dividend.ts
@@ -1,39 +1,39 @@
 // ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
+// FE4 — Istorija dividendi u portfoliju (zadatak 7.1, Developer: Jovan Krunic)
 //
-// Tipovi za istoriju isplacenih dividendi po poziciji u portfoliju.
-//
-// IMPLEMENTIRATI:
-//   - DividendPayoutDto: {
-//       id: number,
-//       listingId: number,
-//       ticker: string,
-//       listingName: string,
-//       accountId: number,
-//       accountNumber: string,
-//       amountPerShare: number,
-//       quantity: number,
-//       totalAmount: number,
-//       currencyCode: string,
-//       exDate: string,       // ISO date — dan kada je vlasnik registrovan za dividendu
-//       paymentDate: string,  // ISO date — dan kada je iznos prenet na racun
-//       createdAt: string,
-//     }
-//   - DividendSummaryDto: {
-//       totalReceivedRsd: number,   // sve dividende konvertovane u RSD
-//       totalReceivedByTicker: Record<string, number>,  // ticker -> ukupni iznos u originalnoj valuti
-//       lastPaymentDate: string | null,
-//     }
-//   - DividendFilterParams: {
-//       ticker?: string,
-//       fromDate?: string,   // ISO date
-//       toDate?: string,     // ISO date
-//       page?: number,
-//       size?: number,
-//     }
-//
-// Konvencija: pratiti postojecu `Savings` feature celinu kao sablon.
-// Spec: Zadaci_Frontend.pdf, FE4.
+// Tipovi odgovaraju B9 backend ugovoru (DividendController / DividendPayoutDto).
 // ============================================================
 
-export {};
+/** Vlasnik koji je primio dividendu. */
+export type DividendOwnerType = 'CLIENT' | 'EMPLOYEE';
+
+/**
+ * Jedna isplacena dividenda — odgovor sa GET /dividends/my i
+ * GET /dividends/by-position/{portfolioId}. Mapira se 1:1 iz BE DividendPayoutDto.
+ */
+export interface DividendPayoutDto {
+  id: number;
+  ownerId: number;
+  ownerType: DividendOwnerType;
+  stockListingId: number;
+  stockTicker: string;
+  quantity: number;
+  /** Cena akcije na dan obracuna. */
+  priceOnDate: number;
+  /** Kvartalni prinos (godisnji dividendYield / 4). */
+  dividendYieldRate: number;
+  /** Bruto iznos pre poreza. */
+  grossAmount: number;
+  /** Iznos poreza po odbitku (0 za EMPLOYEE — vidi taxExempt). */
+  tax: number;
+  /** Neto iznos knjizen na racun. */
+  netAmount: number;
+  creditedAccountId: number;
+  currencyCode: string;
+  /** ISO datum isplate (YYYY-MM-DD). */
+  paymentDate: string;
+  /** true za EMPLOYEE (aktuar drzi akcije u ime banke — bez 15% poreza). */
+  taxExempt: boolean;
+  /** ISO datetime kreiranja zapisa. */
+  createdAt: string;
+}


### PR DESCRIPTION
## FE4 — zadatak 7.1: Istorija dividendi u portfoliju

Uz svaku STOCK poziciju u „Moj portfolio" dodat je expand red sa istorijom primljenih dividendi (datum isplate, količina, bruto, porez, neto, valuta).

### Izmene
- `types/dividend.ts` — `DividendPayoutDto`
- `services/dividendService.ts` — `getMyDividends` + `getDividendsByPosition`
- `pages/Portfolio/PortfolioPage.tsx` — expand red po poziciji, lazy-load, graceful 404
- Vitest: `dividendService` (6) + `PortfolioPage` dividend testovi (7)
- Cypress: `celina3-mock` dividend scenariji (4)

### Testiranje
Svih 8 CI provera zeleno (ESLint, security, TypeScript, Vitest + coverage, npm audit, build, Cypress mocked + live).

### Backend zavisnost (B9)
Servis je usklađen sa B9 ugovorom (`/dividends/my`, `/dividends/by-position/{id}`). B9 još nije na `main`-u, pa UI graciozno hvata 404 i prikazuje „nije dostupno" dok ruta ne postane dostupna (u skladu sa tačkom 1.2 specifikacije — rad uz mock).
