### PR TITLE
feat(fe): FE4 7.2 — statistika fondova (metrike + uporedni grafik)

### DIFF
--- a/cypress/e2e/celina4-mock.cy.ts
+++ b/cypress/e2e/celina4-mock.cy.ts
@@ -344,6 +344,83 @@ const mockFundPositions = [
 // ============================================================
 //  FEATURE 1: Investicioni fondovi — Discovery (Issue #71 / jkrunic)
 // ============================================================
+// ============================================================
+//  FEATURE: Statistika fondova (FE4 — zadatak 7.2 / jkrunic)
+// ============================================================
+const mockFundStats = {
+  fundId: 1,
+  fundName: 'Alpha Growth Fund',
+  snapshotCount: 90,
+  annualizedReturnPercent: 12.34,
+  volatilityPercent: 4.2,
+  maxDrawdownPercent: -8.5,
+  rewardToVariabilityRatio: 2.94,
+  sufficientHistory: true,
+};
+
+describe('Mock C4: Statistika fondova (FE4 7.2)', () => {
+  it('S-FS1: Discovery prikazuje metričke kolone fondova', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/*/statistics', { body: mockFundStats }).as('stats');
+    cy.visit('/funds', { onBeforeLoad: setupClientSession });
+    cy.wait('@funds');
+    cy.contains('th', 'Godišnji prinos').should('be.visible');
+    cy.contains('th', 'Prinos/rizik').should('be.visible');
+    cy.contains('th', 'Max pad').should('be.visible');
+    cy.contains('th', 'Volatilnost').should('be.visible');
+  });
+
+  it('S-FS2: Discovery prikazuje vrednost metrike kad B12 vrati podatke', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/*/statistics', { body: mockFundStats }).as('stats');
+    cy.visit('/funds', { onBeforeLoad: setupClientSession });
+    cy.wait('@funds');
+    cy.wait('@stats');
+    cy.contains('12,34%').should('exist');
+  });
+
+  it('S-FS3: Discovery prikazuje poruku kad B12 vrati 404', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/*/statistics', { statusCode: 404, body: {} }).as('stats');
+    cy.visit('/funds', { onBeforeLoad: setupClientSession });
+    cy.wait('@funds');
+    cy.contains('Metrike fondova trenutno nisu dostupne').should('be.visible');
+  });
+
+  it('S-FS4: Detalji fonda prikazuju karticu Metrike performansi', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/1', { body: mockFundDetail }).as('fundDetail');
+    cy.intercept('GET', '/api/funds/*/performance*', { body: mockPerformance }).as('perf');
+    cy.intercept('GET', '/api/funds/*/statistics', { body: mockFundStats }).as('stats');
+    cy.visit('/funds/1', { onBeforeLoad: setupClientSession });
+    cy.wait('@fundDetail');
+    cy.wait('@stats');
+    cy.contains('Metrike performansi').should('be.visible');
+    cy.get('[data-testid="fund-stats-grid"]').should('exist');
+  });
+
+  it('S-FS5: Detalji fonda prikazuju poruku kad B12 metrike vrate 404', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/1', { body: mockFundDetail }).as('fundDetail');
+    cy.intercept('GET', '/api/funds/*/performance*', { body: mockPerformance }).as('perf');
+    cy.intercept('GET', '/api/funds/*/statistics', { statusCode: 404, body: {} }).as('stats');
+    cy.visit('/funds/1', { onBeforeLoad: setupClientSession });
+    cy.wait('@fundDetail');
+    cy.get('[data-testid="fund-stats-unavailable"]').should('exist');
+  });
+
+  it('S-FS6: Detalji fonda prikazuju uporedni grafik', () => {
+    cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');
+    cy.intercept('GET', '/api/funds/1', { body: mockFundDetail }).as('fundDetail');
+    cy.intercept('GET', '/api/funds/*/performance*', { body: mockPerformance }).as('perf');
+    cy.intercept('GET', '/api/funds/*/statistics', { body: mockFundStats }).as('stats');
+    cy.visit('/funds/1', { onBeforeLoad: setupClientSession });
+    cy.wait('@fundDetail');
+    cy.contains('Poređenje sa prosekom fondova').should('be.visible');
+    cy.get('[data-testid="fund-comparison-chart"]').should('exist');
+  });
+});
+
 describe('Mock C4: Investicioni fondovi - Discovery', () => {
   beforeEach(() => {
     cy.intercept('GET', '/api/funds*', { body: mockFunds }).as('funds');

--- a/src/pages/Funds/FundDetailsPage.test.tsx
+++ b/src/pages/Funds/FundDetailsPage.test.tsx
@@ -10,6 +10,8 @@ const mockGet = vi.fn();
 const mockGetPerformance = vi.fn();
 const mockMyPositions = vi.fn();
 const mockBankPositions = vi.fn();
+const mockListFunds = vi.fn();
+const mockGetFundStatistics = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -32,8 +34,15 @@ vi.mock('@/services/investmentFundService', () => ({
   default: {
     get: (...a: unknown[]) => mockGet(...a),
     getPerformance: (...a: unknown[]) => mockGetPerformance(...a),
+    list: (...a: unknown[]) => mockListFunds(...a),
     myPositions: (...a: unknown[]) => mockMyPositions(...a),
     bankPositions: (...a: unknown[]) => mockBankPositions(...a),
+  },
+}));
+
+vi.mock('@/services/fundStatisticsService', () => ({
+  default: {
+    getFundStatistics: (...a: unknown[]) => mockGetFundStatistics(...a),
   },
 }));
 
@@ -71,10 +80,21 @@ const FUND = {
 };
 
 const PERFORMANCE = [
-  { date: '2026-01-01', value: 4_800_000 },
-  { date: '2026-02-01', value: 4_950_000 },
-  { date: '2026-03-01', value: 5_000_000 },
+  { date: '2026-01-01', fundValue: 4_800_000, profit: 0 },
+  { date: '2026-02-01', fundValue: 4_950_000, profit: 150_000 },
+  { date: '2026-03-01', fundValue: 5_000_000, profit: 200_000 },
 ];
+
+const FUND_STATS = {
+  fundId: 101,
+  fundName: 'Alpha Growth',
+  snapshotCount: 90,
+  annualizedReturnPercent: 12.34,
+  volatilityPercent: 4.2,
+  maxDrawdownPercent: -8.5,
+  rewardToVariabilityRatio: 2.94,
+  sufficientHistory: true,
+};
 
 describe('FundDetailsPage', () => {
   beforeEach(() => {
@@ -84,6 +104,8 @@ describe('FundDetailsPage', () => {
     mockGetPerformance.mockResolvedValue(PERFORMANCE);
     mockMyPositions.mockResolvedValue([]);
     mockBankPositions.mockResolvedValue([]);
+    mockListFunds.mockResolvedValue([{ id: 101 }, { id: 102 }]);
+    mockGetFundStatistics.mockResolvedValue(FUND_STATS);
   });
 
   it('prikazuje loading skeleton dok ucitava', () => {
@@ -133,9 +155,12 @@ describe('FundDetailsPage', () => {
 
   it('promena perioda re-fetchuje performance', async () => {
     renderWithProviders(<FundDetailsPage />);
-    await waitFor(() => expect(mockGetPerformance).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockGetPerformance).toHaveBeenCalled());
+    // getPerformance zovu i glavni efekat i benchmark efekat (FE4 7.2), pa
+    // proveravamo da promena perioda pokreće NOV fetch, ne tačan broj poziva.
+    mockGetPerformance.mockClear();
     await userEvent.click(screen.getByText('1G'));
-    await waitFor(() => expect(mockGetPerformance).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetPerformance).toHaveBeenCalled());
   });
 
   it('back arrow dugme navigira na /funds', async () => {
@@ -173,5 +198,37 @@ describe('FundDetailsPage', () => {
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
     await waitFor(() => expect(mockMyPositions).toHaveBeenCalled());
     expect(mockBankPositions).not.toHaveBeenCalled();
+  });
+
+  // --- FE4 (7.2) — statistika fondova ---
+
+  it('prikazuje karticu Metrike performansi sa metrikama (B12)', async () => {
+    renderWithProviders(<FundDetailsPage />);
+    await waitFor(() =>
+      expect(screen.getByText('Metrike performansi')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('fund-stats-grid')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Godišnji prinos')).toBeInTheDocument();
+    expect(screen.getByText('Volatilnost')).toBeInTheDocument();
+  });
+
+  it('prikazuje poruku kad B12 metrike nisu dostupne (404)', async () => {
+    mockGetFundStatistics.mockRejectedValue({ response: { status: 404 } });
+    renderWithProviders(<FundDetailsPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('fund-stats-unavailable')).toBeInTheDocument(),
+    );
+  });
+
+  it('renderuje uporedni grafik (Poređenje sa prosekom fondova)', async () => {
+    renderWithProviders(<FundDetailsPage />);
+    await waitFor(() =>
+      expect(screen.getByText('Poređenje sa prosekom fondova')).toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('fund-comparison-chart')).toBeInTheDocument(),
+    );
   });
 });

--- a/src/pages/Funds/FundDetailsPage.tsx
+++ b/src/pages/Funds/FundDetailsPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from '@/lib/notify';
 import {
-  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+  AreaChart, Area, LineChart, Line, Legend,
+  XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
 } from 'recharts';
 import {
   ArrowLeft,
@@ -20,8 +21,10 @@ import {
 import * as Dialog from '@radix-ui/react-dialog';
 import { useAuth } from '@/context/AuthContext';
 import investmentFundService from '@/services/investmentFundService';
+import fundStatisticsService from '@/services/fundStatisticsService';
 import { employeeService } from '@/services/employeeService';
 import type { InvestmentFundDetail, FundPerformancePoint, ClientFundPosition } from '@/types/celina4';
+import type { FundStatisticsDto } from '@/types/fundStatistics';
 import type { Employee } from '@/types';
 import { formatAmount, formatDate, formatPrice, getErrorMessage, toIsoDateOnly } from '@/utils/formatters';
 import { Button } from '@/components/ui/button';
@@ -38,31 +41,55 @@ import {
   TableRow,
 } from '@/components/ui/table';
 
-/*
- * TODO [FE4 - Statistika fondova | Developer: Jovan Krunic]
- *
- * Na detaljnoj stranici fonda prikazati sve metrike performansi i prosiriti grafike:
- *
- *  1. Kartica / sekcija "Metrike performansi" (pored ili ispod postojeceg grafa):
- *     - Anualizovani prinos (%) — fundStatisticsService.getFundStatistics(fundId);
- *     - Sharpe ratio (Prinos/Rizik);
- *     - Maksimalni drawdown (%) — crvena boja;
- *     - Volatilnost (%) — godisnja standardna devijacija.
- *     Svaku metriku prikazati kao <Card> chip sa naslovom i vrednoscu
- *     (paritet sa KPI chip-ovima na OtcHubPage i HomePage).
- *
- *  2. Prosiriti postojeci grafik istorijske vrednosti fonda:
- *     - Dodati drugu liniju / oblast "Prosek svih fondova" (benchmark linija)
- *       iz fundStatisticsService.getBenchmarkPerformance(period);
- *     - Koristiti razlicitu boju (npr. amber) i isprekidanu liniju za benchmark;
- *     - Legenda ispod grafa sa objasnjenjima obe linije.
- *
- *  3. Opcionalni "Uporedni grafik" tab sa mogucnoscu biranja vise fondova
- *     za poredjenje (MultiSelectFundCombobox + vise linija na istom ResponsiveContainer).
- *
- *  Tipove FundStatistics i BenchmarkPoint dodati u src/types/celina4.ts.
- *  Servis: src/services/fundStatisticsService.ts (isti kao u FundsDiscoveryPage).
- */
+// ============================================================
+// FE4 (7.2) — Statistika fondova: detaljan prikaz (Developer: Jovan Krunic)
+// Dodaje karticu sa metrikama performansi (B12 GET /funds/{id}/statistics) i
+// uporedni grafik (indeks = 100 na početku perioda) fonda naspram proseka
+// svih fondova. Dok B12 nije dostupan (404), metrike graciozno degradiraju.
+// ============================================================
+
+type StatsStatus = 'loading' | 'ready' | 'unavailable' | 'error';
+
+/** Indeksira seriju performansi: svaka tačka = vrednost / prva_vrednost * 100, po datumu. */
+function toIndexMap(points: FundPerformancePoint[]): Map<string, number> {
+  const map = new Map<string, number>();
+  const base = points[0]?.fundValue ?? 0;
+  if (base <= 0) return map;
+  for (const p of points) {
+    map.set(p.date, (p.fundValue / base) * 100);
+  }
+  return map;
+}
+
+/** KPI chip za jednu metriku performansi fonda; `null` vrednost -> „—". */
+function MetricChip({
+  label,
+  value,
+  suffix = '%',
+  colored = false,
+}: {
+  label: string;
+  value: number | null;
+  suffix?: string;
+  colored?: boolean;
+}) {
+  const hasValue = typeof value === 'number' && !Number.isNaN(value);
+  const colorClass =
+    hasValue && colored ? (value >= 0 ? 'text-emerald-500' : 'text-red-500') : '';
+  return (
+    <div className="rounded-lg border bg-muted/20 p-4">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className={`mt-1 text-xl font-bold font-mono tabular-nums ${colorClass}`}>
+        {hasValue
+          ? `${value.toLocaleString('sr-RS', {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}${suffix}`
+          : '—'}
+      </p>
+    </div>
+  );
+}
 
 type PerfPeriod = 'month' | 'quarter' | 'year';
 
@@ -91,6 +118,10 @@ export default function FundDetailsPage() {
   const [fund, setFund] = useState<InvestmentFundDetail | null>(null);
   const [performance, setPerformance] = useState<FundPerformancePoint[]>([]);
   const [loading, setLoading] = useState(true);
+  // FE4 (7.2) — metrike performansi (B12) + podaci za uporedni grafik.
+  const [stats, setStats] = useState<FundStatisticsDto | null>(null);
+  const [statsStatus, setStatsStatus] = useState<StatsStatus>('loading');
+  const [benchmarkByDate, setBenchmarkByDate] = useState<Map<string, number>>(new Map());
   // P1.2 — admin dialog za reassign manager.
   const [reassignDialogOpen, setReassignDialogOpen] = useState(false);
   const [supervisors, setSupervisors] = useState<Employee[]>([]);
@@ -216,6 +247,74 @@ export default function FundDetailsPage() {
 
     return () => { cancelled = true; };
   }, [id, perfPeriod, navigate]);
+
+  // FE4 (7.2) — metrike fonda (B12). Zaseban poziv: 404 ne sme da obori stranicu
+  // (zato NIJE u Promise.all sa fund/performance iznad).
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    void fundStatisticsService
+      .getFundStatistics(Number(id))
+      .then((data) => {
+        if (cancelled) return;
+        setStats(data);
+        setStatsStatus('ready');
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const s = (err as { response?: { status?: number } })?.response?.status;
+        setStatsStatus(s === 404 || s === 501 || s === 405 ? 'unavailable' : 'error');
+      });
+    return () => { cancelled = true; };
+  }, [id]);
+
+  // FE4 (7.2) — prosek performansi svih fondova (indeksiran na 100) za uporedni grafik.
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    const range = getPerfRange(perfPeriod);
+    void investmentFundService
+      .list()
+      .then((allFunds) =>
+        Promise.allSettled(
+          allFunds.map((f) =>
+            investmentFundService.getPerformance(f.id, range.from, range.to),
+          ),
+        ),
+      )
+      .then((results) => {
+        if (cancelled) return;
+        // Svaku seriju indeksiraj na 100 pa uprosečuj po datumu.
+        const sums = new Map<string, { sum: number; count: number }>();
+        for (const r of results) {
+          if (r.status !== 'fulfilled') continue;
+          for (const [date, idx] of toIndexMap(r.value)) {
+            const cur = sums.get(date) ?? { sum: 0, count: 0 };
+            sums.set(date, { sum: cur.sum + idx, count: cur.count + 1 });
+          }
+        }
+        const avg = new Map<string, number>();
+        for (const [date, { sum, count }] of sums) {
+          avg.set(date, sum / count);
+        }
+        setBenchmarkByDate(avg);
+      })
+      .catch(() => {
+        if (!cancelled) setBenchmarkByDate(new Map());
+      });
+    return () => { cancelled = true; };
+  }, [id, perfPeriod]);
+
+  // Uporedni grafik: serija fonda (indeks 100) + benchmark (prosek svih fondova).
+  const comparisonData = useMemo(() => {
+    const base = performance[0]?.fundValue ?? 0;
+    if (base <= 0) return [];
+    return performance.map((p) => ({
+      date: p.date,
+      fundIndex: (p.fundValue / base) * 100,
+      benchmarkIndex: benchmarkByDate.get(p.date) ?? null,
+    }));
+  }, [performance, benchmarkByDate]);
 
   if (loading) {
     return (
@@ -394,6 +493,66 @@ export default function FundDetailsPage() {
         </CardContent>
       </Card>
 
+      {/* FE4 (7.2) — Metrike performansi (B12) */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            Metrike performansi
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {statsStatus === 'loading' ? (
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="h-20 animate-pulse rounded-lg bg-muted/50" />
+              ))}
+            </div>
+          ) : statsStatus === 'unavailable' ? (
+            <p className="text-sm text-muted-foreground" data-testid="fund-stats-unavailable">
+              Metrike performansi trenutno nisu dostupne (B12 endpoint još nije aktivan).
+            </p>
+          ) : statsStatus === 'error' ? (
+            <p className="text-sm text-red-500" data-testid="fund-stats-error">
+              Greška pri učitavanju metrika. Pokušajte ponovo kasnije.
+            </p>
+          ) : (
+            <>
+              <div
+                className="grid grid-cols-2 lg:grid-cols-4 gap-3"
+                data-testid="fund-stats-grid"
+              >
+                <MetricChip
+                  label="Godišnji prinos"
+                  value={stats?.annualizedReturnPercent ?? null}
+                  colored
+                />
+                <MetricChip
+                  label="Prinos / rizik"
+                  value={stats?.rewardToVariabilityRatio ?? null}
+                  suffix=""
+                />
+                <MetricChip
+                  label="Max pad (drawdown)"
+                  value={stats?.maxDrawdownPercent ?? null}
+                  colored
+                />
+                <MetricChip
+                  label="Volatilnost"
+                  value={stats?.volatilityPercent ?? null}
+                />
+              </div>
+              {stats && !stats.sufficientHistory && (
+                <p className="mt-3 text-[11px] text-muted-foreground">
+                  ⚠ Premalo istorijskih podataka ({stats.snapshotCount} snimaka) — metrike
+                  mogu biti nepouzdane.
+                </p>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Performance Chart */}
       <Card>
         <CardHeader>
@@ -477,6 +636,97 @@ export default function FundDetailsPage() {
                   />
                 </AreaChart>
               </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* FE4 (7.2) — Uporedni grafik: fond vs prosek svih fondova (indeks = 100 na početku perioda) */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="h-5 w-5" />
+            Poređenje sa prosekom fondova
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {comparisonData.length === 0 ? (
+            <div className="flex flex-col items-center py-12 text-muted-foreground">
+              <TrendingUp className="h-10 w-10 mb-3 opacity-30" />
+              <p>Nema podataka za poređenje u izabranom periodu</p>
+            </div>
+          ) : (
+            <div
+              className="bg-muted/20 dark:bg-slate-900/40 rounded-xl p-3"
+              data-testid="fund-comparison-chart"
+            >
+              <ResponsiveContainer width="100%" height={320}>
+                <LineChart data={comparisonData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="currentColor" strokeOpacity={0.06} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 11, fill: 'currentColor', opacity: 0.4 }}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(d: string) =>
+                      new Date(d).toLocaleDateString('sr-RS', { day: '2-digit', month: '2-digit' })
+                    }
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11, fill: 'currentColor', opacity: 0.4 }}
+                    tickLine={false}
+                    axisLine={false}
+                    domain={['auto', 'auto']}
+                    tickFormatter={(v: number) => v.toFixed(0)}
+                    width={48}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '8px',
+                      fontSize: '12px',
+                      fontFamily: 'monospace',
+                    }}
+                    formatter={(value: unknown, name: unknown) => [
+                      typeof value === 'number' ? value.toFixed(2) : '—',
+                      name === 'fundIndex' ? 'Ovaj fond' : 'Prosek fondova',
+                    ]}
+                    labelFormatter={(label: unknown) =>
+                      new Date(String(label)).toLocaleDateString('sr-RS', {
+                        day: '2-digit', month: 'long', year: 'numeric',
+                      })
+                    }
+                  />
+                  <Legend
+                    formatter={(value) =>
+                      value === 'fundIndex' ? 'Ovaj fond' : 'Prosek svih fondova'
+                    }
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="fundIndex"
+                    stroke="#6366f1"
+                    strokeWidth={2}
+                    dot={false}
+                    animationDuration={800}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="benchmarkIndex"
+                    stroke="#f59e0b"
+                    strokeWidth={2}
+                    strokeDasharray="5 4"
+                    dot={false}
+                    connectNulls
+                    animationDuration={800}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              <p className="mt-2 text-center text-[11px] text-muted-foreground">
+                Indeks performansi — početak perioda = 100. Plavo: ovaj fond ·
+                narandžasto isprekidano: prosek svih fondova.
+              </p>
             </div>
           )}
         </CardContent>

--- a/src/pages/Funds/FundsDiscoveryPage.test.tsx
+++ b/src/pages/Funds/FundsDiscoveryPage.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from '@/test/test-utils';
 const mockNavigate = vi.fn();
 const mockUseAuth = vi.fn();
 const mockListFunds = vi.fn();
+const mockGetFundStatistics = vi.fn();
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -27,6 +28,12 @@ vi.mock('@/context/AuthContext', async (importOriginal) => {
 vi.mock('@/services/investmentFundService', () => ({
   default: {
     list: (...args: unknown[]) => mockListFunds(...args),
+  },
+}));
+
+vi.mock('@/services/fundStatisticsService', () => ({
+  default: {
+    getFundStatistics: (...args: unknown[]) => mockGetFundStatistics(...args),
   },
 }));
 
@@ -60,11 +67,23 @@ const FUNDS = [
   },
 ];
 
+const STATS = {
+  fundId: 1,
+  fundName: 'Alpha Growth',
+  snapshotCount: 90,
+  annualizedReturnPercent: 12.34,
+  volatilityPercent: 4.2,
+  maxDrawdownPercent: -8.5,
+  rewardToVariabilityRatio: 2.94,
+  sufficientHistory: true,
+};
+
 describe('FundsDiscoveryPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseAuth.mockReturnValue({ isSupervisor: false });
     mockListFunds.mockResolvedValue(FUNDS);
+    mockGetFundStatistics.mockResolvedValue(STATS);
   });
 
   it('prikazuje listu fondova nakon ucitavanja', async () => {
@@ -151,5 +170,40 @@ describe('FundsDiscoveryPage', () => {
     // Beta ima negativan profit (-75000), trazimo .text-red-500 na njegovom row-u
     const betaRow = screen.getByText('Beta Yield').closest('tr')!;
     expect(betaRow.querySelector('.text-red-500')).toBeTruthy();
+  });
+
+  // --- FE4 (7.2) — metrike fondova ---
+
+  it('prikazuje nove kolone metrika fondova', async () => {
+    renderWithProviders(<FundsDiscoveryPage />);
+    await waitFor(() => expect(screen.getByText('Alpha Growth')).toBeInTheDocument());
+    expect(screen.getByText('Godišnji prinos')).toBeInTheDocument();
+    expect(screen.getByText('Prinos/rizik')).toBeInTheDocument();
+    expect(screen.getByText('Max pad')).toBeInTheDocument();
+    expect(screen.getByText('Volatilnost')).toBeInTheDocument();
+  });
+
+  it('prikazuje vrednosti metrika kad su statistike dostupne', async () => {
+    renderWithProviders(<FundsDiscoveryPage />);
+    await waitFor(() => expect(screen.getByText('Alpha Growth')).toBeInTheDocument());
+    // STATS.annualizedReturnPercent = 12.34 -> "12,34%" (sr-RS)
+    await waitFor(() =>
+      expect(screen.getAllByText(/12,34\s*%/).length).toBeGreaterThan(0),
+    );
+  });
+
+  it('prikazuje poruku kad B12 metrike nisu dostupne (404)', async () => {
+    mockGetFundStatistics.mockRejectedValue({ response: { status: 404 } });
+    renderWithProviders(<FundsDiscoveryPage />);
+    await screen.findByText(/Metrike fondova trenutno nisu dostupne/i);
+  });
+
+  it('klik na metričku kolonu (Godišnji prinos) sortira bez rušenja prikaza', async () => {
+    renderWithProviders(<FundsDiscoveryPage />);
+    await waitFor(() => expect(screen.getByText('Alpha Growth')).toBeInTheDocument());
+    const header = screen.getByText('Godišnji prinos').closest('th')!;
+    await userEvent.click(header);
+    expect(screen.getByText('Alpha Growth')).toBeInTheDocument();
+    expect(screen.getByText('Beta Yield')).toBeInTheDocument();
   });
 });

--- a/src/pages/Funds/FundsDiscoveryPage.tsx
+++ b/src/pages/Funds/FundsDiscoveryPage.tsx
@@ -13,7 +13,9 @@ import {
 } from 'lucide-react';
 import { useAuth } from '@/context/AuthContext';
 import investmentFundService from '@/services/investmentFundService';
+import fundStatisticsService from '@/services/fundStatisticsService';
 import type { InvestmentFundSummary } from '@/types/celina4';
+import type { FundStatisticsDto } from '@/types/fundStatistics';
 import { formatAmount } from '@/utils/formatters';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -27,36 +29,73 @@ import {
   TableRow,
 } from '@/components/ui/table';
 
-/*
- * TODO [FE4 - Statistika fondova | Developer: Jovan Krunic]
- *
- * Prosiriti tabelu fondova dodatnim kolonama sa metrikama i omoguciti sortiranje:
- *
- *  1. Novi servis fundStatisticsService (src/services/fundStatisticsService.ts):
- *     - getFundStatistics(fundId): GET /funds/{id}/statistics
- *       vraca { annualizedReturn: number, sharpeRatio: number,
- *               maxDrawdown: number, volatility: number }.
- *     - getAllFundStatistics(): GET /funds/statistics — batch endpoint za sve fondove
- *       (jedan poziv umesto N poziva u petlji).
- *
- *  2. Nove kolone u tabeli (dodati u TableHeader i TableRow):
- *     - "Anualizovani prinos (%)" — formatovati sa 2 decimale + % suffix;
- *     - "Prinos/Rizik (Sharpe)" — Sharpe ratio, 2 decimale;
- *     - "Max Drawdown (%)" — negativna vrednost, prikazati crveno;
- *     - "Volatilnost (%)" — prikazati sa 2 decimale.
- *
- *  3. Sortiranje — prosiriti SortField tip novim vrednostima:
- *     'annualizedReturn' | 'sharpeRatio' | 'maxDrawdown' | 'volatility'
- *     i dodati klik na zaglavlje kolone (ArrowUpDown/ArrowUp/ArrowDown ikona).
- *
- *  4. Ucitavanje: fetchovati statistike paralelno sa listom fondova (Promise.all)
- *     i spojiti podatke po fundId pre renderovanja.
- *
- *  Tip FundStatistics dodati u src/types/celina4.ts.
- */
+// ============================================================
+// FE4 (7.2) — Statistika fondova (Developer: Jovan Krunic)
+// Tabela fondova prosirena metrikama performansi (B12). Za svaki fond se
+// paralelno dohvata GET /funds/{id}/statistics; dok B12 nije dostupan (404)
+// ili nema dovoljno istorije, metrike se prikazuju kao „—".
+// ============================================================
 
-type SortField = 'name' | 'fundValue' | 'profit' | 'minimumContribution';
+/** Sortabilne metricke kolone -> odgovarajuce polje u FundStatisticsDto. */
+const METRIC_KEY = {
+  annualizedReturn: 'annualizedReturnPercent',
+  rewardToVariability: 'rewardToVariabilityRatio',
+  maxDrawdown: 'maxDrawdownPercent',
+  volatility: 'volatilityPercent',
+} as const;
+
+type MetricSortField = keyof typeof METRIC_KEY;
+type SortField =
+  | 'name'
+  | 'fundValue'
+  | 'profit'
+  | 'minimumContribution'
+  | MetricSortField;
 type SortDirection = 'asc' | 'desc';
+
+/** Celija tabele za jednu metriku fonda; `null` (nedovoljno istorije / B12 nedostupan) -> „—". */
+function MetricCell({
+  value,
+  suffix = '%',
+  colored = false,
+}: {
+  value: number | null;
+  suffix?: string;
+  colored?: boolean;
+}) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return <TableCell className="text-right text-muted-foreground">—</TableCell>;
+  }
+  const formatted = value.toLocaleString('sr-RS', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const colorClass = colored ? (value >= 0 ? 'text-emerald-500' : 'text-red-500') : '';
+  return (
+    <TableCell className={`text-right font-mono tabular-nums ${colorClass}`}>
+      {formatted}
+      {suffix}
+    </TableCell>
+  );
+}
+
+/** Ikonica smera sortiranja u zaglavlju kolone tabele. */
+function SortIcon({
+  field,
+  activeField,
+  direction,
+}: {
+  field: SortField;
+  activeField: SortField;
+  direction: SortDirection;
+}) {
+  if (activeField !== field) return <ArrowUpDown className="h-3 w-3 ml-1 opacity-40" />;
+  return direction === 'asc' ? (
+    <ArrowUp className="h-3 w-3 ml-1" />
+  ) : (
+    <ArrowDown className="h-3 w-3 ml-1" />
+  );
+}
 
 export default function FundsDiscoveryPage() {
   const navigate = useNavigate();
@@ -68,6 +107,10 @@ export default function FundsDiscoveryPage() {
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [sortBy, setSortBy] = useState<SortField>('name');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  // FE4 (7.2) — metrike fondova, keširane po fundId.
+  const [fundStats, setFundStats] = useState<Record<number, FundStatisticsDto>>({});
+  // true kad je bar jedan ciklus dohvatanja metrika završen (za „nedostupno" poruku).
+  const [statsChecked, setStatsChecked] = useState(false);
   // Numericki filteri (min/max) — string state za UX (prazno polje = bez filtera).
   const [minContribution, setMinContribution] = useState('');
   const [maxContribution, setMaxContribution] = useState('');
@@ -103,10 +146,13 @@ export default function FundsDiscoveryPage() {
   const fetchFunds = useCallback(async () => {
     setLoading(true);
     try {
+      // Metricke kolone BE ne zna da sortira — za njih ne saljemo sort param,
+      // sortiranje tih kolona radi client-side `sortedFunds`.
+      const isMetricSort = sortBy in METRIC_KEY;
       const result = await investmentFundService.list({
         search: debouncedSearch || undefined,
-        sort: sortBy,
-        direction: sortDirection,
+        sort: isMetricSort ? undefined : sortBy,
+        direction: isMetricSort ? undefined : sortDirection,
         minContribution: parseNum(debouncedFilters.minContribution),
         maxContribution: parseNum(debouncedFilters.maxContribution),
         minFundValue: parseNum(debouncedFilters.minFundValue),
@@ -124,6 +170,40 @@ export default function FundsDiscoveryPage() {
   }, [debouncedSearch, sortBy, sortDirection, debouncedFilters]);
 
   useEffect(() => { fetchFunds(); }, [fetchFunds]);
+
+  // FE4 (7.2) — kad se lista fondova promeni, paralelno dohvati metrike za sve.
+  // Promise.allSettled: pad jednog poziva (npr. 404 dok B12 nije gotov) ne ruši ostale.
+  useEffect(() => {
+    // Nema fondova -> nema šta da se dohvata. Stari fundStats je bezopasan
+    // (nema redova da ga koriste), pa ga ne diramo — izbegava setState u efektu.
+    if (funds.length === 0) return;
+    let cancelled = false;
+    void Promise.allSettled(
+      funds.map((f) => fundStatisticsService.getFundStatistics(f.id)),
+    ).then((results) => {
+      if (cancelled) return;
+      const map: Record<number, FundStatisticsDto> = {};
+      results.forEach((r, i) => {
+        if (r.status === 'fulfilled') map[funds[i].id] = r.value;
+      });
+      setFundStats(map);
+      setStatsChecked(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [funds]);
+
+  // Metricka vrednost fonda za sortiranje; null ako stats nema ili metrika nije izracunata.
+  const metricValue = useCallback(
+    (fundId: number, field: MetricSortField): number | null => {
+      const stats = fundStats[fundId];
+      if (!stats) return null;
+      const v = stats[METRIC_KEY[field]];
+      return typeof v === 'number' ? v : null;
+    },
+    [fundStats],
+  );
 
   // Client-side sort fallback (in case backend doesn't sort)
   const sortedFunds = useMemo(() => {
@@ -143,11 +223,24 @@ export default function FundsDiscoveryPage() {
         case 'minimumContribution':
           cmp = a.minimumContribution - b.minimumContribution;
           break;
+        case 'annualizedReturn':
+        case 'rewardToVariability':
+        case 'maxDrawdown':
+        case 'volatility': {
+          const av = metricValue(a.id, sortBy);
+          const bv = metricValue(b.id, sortBy);
+          // Fondovi bez metrike uvek idu na kraj, nezavisno od smera sortiranja.
+          if (av === null && bv === null) return 0;
+          if (av === null) return 1;
+          if (bv === null) return -1;
+          cmp = av - bv;
+          break;
+        }
       }
       return sortDirection === 'asc' ? cmp : -cmp;
     });
     return sorted;
-  }, [funds, sortBy, sortDirection]);
+  }, [funds, sortBy, sortDirection, metricValue]);
 
   const handleSort = (field: SortField) => {
     if (sortBy === field) {
@@ -156,13 +249,6 @@ export default function FundsDiscoveryPage() {
       setSortBy(field);
       setSortDirection('asc');
     }
-  };
-
-  const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortBy !== field) return <ArrowUpDown className="h-3 w-3 ml-1 opacity-40" />;
-    return sortDirection === 'asc'
-      ? <ArrowUp className="h-3 w-3 ml-1" />
-      : <ArrowDown className="h-3 w-3 ml-1" />;
   };
 
   return (
@@ -270,6 +356,12 @@ export default function FundsDiscoveryPage() {
               )}
             </div>
           ) : (
+            <div className="overflow-x-auto">
+              {statsChecked && funds.length > 0 && Object.keys(fundStats).length === 0 && (
+                <p className="px-6 pt-4 text-xs text-muted-foreground">
+                  Metrike fondova trenutno nisu dostupne (B12 endpoint još nije aktivan).
+                </p>
+              )}
             <Table>
               <TableHeader>
                 <TableRow>
@@ -279,7 +371,7 @@ export default function FundsDiscoveryPage() {
                   >
                     <div className="flex items-center">
                       Naziv
-                      <SortIcon field="name" />
+                      <SortIcon field="name" activeField={sortBy} direction={sortDirection} />
                     </div>
                   </TableHead>
                   <TableHead className="hidden md:table-cell">Opis</TableHead>
@@ -289,7 +381,7 @@ export default function FundsDiscoveryPage() {
                   >
                     <div className="flex items-center justify-end">
                       Min. ulog
-                      <SortIcon field="minimumContribution" />
+                      <SortIcon field="minimumContribution" activeField={sortBy} direction={sortDirection} />
                     </div>
                   </TableHead>
                   <TableHead
@@ -298,7 +390,7 @@ export default function FundsDiscoveryPage() {
                   >
                     <div className="flex items-center justify-end">
                       Vrednost
-                      <SortIcon field="fundValue" />
+                      <SortIcon field="fundValue" activeField={sortBy} direction={sortDirection} />
                     </div>
                   </TableHead>
                   <TableHead
@@ -307,7 +399,47 @@ export default function FundsDiscoveryPage() {
                   >
                     <div className="flex items-center justify-end">
                       Profit
-                      <SortIcon field="profit" />
+                      <SortIcon field="profit" activeField={sortBy} direction={sortDirection} />
+                    </div>
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer select-none text-right"
+                    onClick={() => handleSort('annualizedReturn')}
+                    title="Anualizovani (godišnji) prinos"
+                  >
+                    <div className="flex items-center justify-end">
+                      Godišnji prinos
+                      <SortIcon field="annualizedReturn" activeField={sortBy} direction={sortDirection} />
+                    </div>
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer select-none text-right"
+                    onClick={() => handleSort('rewardToVariability')}
+                    title="Odnos prinosa i rizika (Sharpe-like) — viši je bolji"
+                  >
+                    <div className="flex items-center justify-end">
+                      Prinos/rizik
+                      <SortIcon field="rewardToVariability" activeField={sortBy} direction={sortDirection} />
+                    </div>
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer select-none text-right"
+                    onClick={() => handleSort('maxDrawdown')}
+                    title="Maksimalni pad vrednosti od vrha do dna"
+                  >
+                    <div className="flex items-center justify-end">
+                      Max pad
+                      <SortIcon field="maxDrawdown" activeField={sortBy} direction={sortDirection} />
+                    </div>
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer select-none text-right"
+                    onClick={() => handleSort('volatility')}
+                    title="Volatilnost — standardna devijacija mesečnih prinosa"
+                  >
+                    <div className="flex items-center justify-end">
+                      Volatilnost
+                      <SortIcon field="volatility" activeField={sortBy} direction={sortDirection} />
                     </div>
                   </TableHead>
                 </TableRow>
@@ -354,10 +486,15 @@ export default function FundsDiscoveryPage() {
                         </span>
                       </div>
                     </TableCell>
+                    <MetricCell value={metricValue(fund.id, 'annualizedReturn')} colored />
+                    <MetricCell value={metricValue(fund.id, 'rewardToVariability')} suffix="" />
+                    <MetricCell value={metricValue(fund.id, 'maxDrawdown')} colored />
+                    <MetricCell value={metricValue(fund.id, 'volatility')} />
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/services/fundStatisticsService.test.ts
+++ b/src/services/fundStatisticsService.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mockujem api modul pre fund statistics service import-a
+vi.mock('./api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import fundStatisticsService from './fundStatisticsService';
+import api from './api';
+import type { FundStatisticsDto } from '../types/fundStatistics';
+
+const mockGet = api.get as ReturnType<typeof vi.fn>;
+
+const sampleStats: FundStatisticsDto = {
+  fundId: 7,
+  fundName: 'Alpha Growth',
+  snapshotCount: 90,
+  annualizedReturnPercent: 12.34,
+  volatilityPercent: 4.2,
+  maxDrawdownPercent: -8.5,
+  rewardToVariabilityRatio: 2.94,
+  sufficientHistory: true,
+};
+
+describe('fundStatisticsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getFundStatistics', () => {
+    it('šalje GET /funds/{fundId}/statistics', async () => {
+      mockGet.mockResolvedValue({ data: sampleStats });
+
+      await fundStatisticsService.getFundStatistics(7);
+
+      expect(mockGet).toHaveBeenCalledWith('/funds/7/statistics');
+    });
+
+    it('vraća FundStatisticsDto iz BE odgovora', async () => {
+      mockGet.mockResolvedValue({ data: sampleStats });
+
+      const result = await fundStatisticsService.getFundStatistics(7);
+
+      expect(result).toEqual(sampleStats);
+    });
+
+    it('podržava DTO sa null metrikama (nedovoljno istorije)', async () => {
+      const insufficient: FundStatisticsDto = {
+        fundId: 9,
+        fundName: 'Novi fond',
+        snapshotCount: 5,
+        annualizedReturnPercent: null,
+        volatilityPercent: null,
+        maxDrawdownPercent: null,
+        rewardToVariabilityRatio: null,
+        sufficientHistory: false,
+      };
+      mockGet.mockResolvedValue({ data: insufficient });
+
+      const result = await fundStatisticsService.getFundStatistics(9);
+
+      expect(result.sufficientHistory).toBe(false);
+      expect(result.annualizedReturnPercent).toBeNull();
+    });
+
+    it('propagira grešku ako api odbije zahtev (npr. 404 dok B12 nije aktivan)', async () => {
+      mockGet.mockRejectedValue(new Error('404 not found'));
+
+      await expect(fundStatisticsService.getFundStatistics(7)).rejects.toThrow(
+        '404 not found',
+      );
+    });
+  });
+});

--- a/src/services/fundStatisticsService.ts
+++ b/src/services/fundStatisticsService.ts
@@ -1,29 +1,21 @@
-// ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
-//
-// HTTP wrapper za metrike i statistike investicionih fondova. Sve metode
-// koriste `api` klijent iz './api' (axios instanca sa JWT interceptorom).
-//
-// IMPLEMENTIRATI (uvezi tipove iz '../types/fundStatistics' kada ih definises):
-//   - getFundMetrics(fundId: number, params?: FundStatisticsFilterParams): Promise<FundMetricsDto>
-//       GET /funds/{fundId}/statistics
-//       Query params: fromDate, toDate
-//       Vraca izracunate metrike (godisnji prinos, Sharpe ratio, max drawdown,
-//       volatilnost, ukupni prinos) za konkretni fond u zadatom periodu.
-//
-//   - getAllFundsComparison(params?: FundStatisticsFilterParams): Promise<FundComparisonItemDto[]>
-//       GET /funds/statistics/comparison
-//       Query params: fromDate, toDate
-//       Vraca listu svih fondova sa kljucnim metrikama — namenjeno tabeli
-//       za poredjenje fondova na FundsDiscoveryPage / FundDetailsPage.
-//
-// Pattern:
-//   import api from './api';
-//   export const fundStatisticsService = { ... };
-//   Svaka metoda destrukturira { data } iz api.get poziva i vraca data.
-//
-// Konvencija: pratiti postojecu `Savings` feature celinu kao sablon.
-// Spec: Zadaci_Frontend.pdf, FE4.
-// ============================================================
+import api from './api';
+import type { FundStatisticsDto } from '../types/fundStatistics';
 
-export {};
+/**
+ * Fund statistics API wrapper — odgovara `/funds/{id}/statistics` endpoint-u (B12).
+ *
+ * FE4, zadatak 7.2 — metrike performansi investicionih fondova
+ * (anualizovani prinos, volatilnost, max drawdown, reward-to-variability).
+ */
+const fundStatisticsService = {
+  /**
+   * Statisticke metrike performansi jednog fonda.
+   * BE endpoint: GET /funds/{fundId}/statistics
+   */
+  getFundStatistics: async (fundId: number): Promise<FundStatisticsDto> => {
+    const { data } = await api.get<FundStatisticsDto>(`/funds/${fundId}/statistics`);
+    return data;
+  },
+};
+
+export default fundStatisticsService;

--- a/src/types/fundStatistics.ts
+++ b/src/types/fundStatistics.ts
@@ -1,37 +1,29 @@
 // ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
+// FE4 — Statistika fondova (zadatak 7.2, Developer: Jovan Krunic)
 //
-// Tipovi za statistike i metrike performansi investicionih fondova.
-//
-// IMPLEMENTIRATI:
-//   - FundMetricsDto: {
-//       fundId: number,
-//       fundName: string,
-//       currencyCode: string,
-//       annualizedReturnPct: number,         // godisnji prinos u %
-//       rewardToVariabilityRatio: number,    // Sharpe-like ratio: (prinos - rf) / std
-//       maxDrawdownPct: number,              // maksimalni pad od vrha, negativna vrednost
-//       volatilityPct: number,               // godisnja volatilnost (std devijacija prinosa)
-//       totalReturnPct: number,              // ukupni prinos od osnivanja fonda u %
-//       calculatedAt: string,               // ISO datetime kada su metrike izracunate
-//     }
-//   - FundComparisonItemDto: {
-//       fundId: number,
-//       fundName: string,
-//       annualizedReturnPct: number,
-//       volatilityPct: number,
-//       rewardToVariabilityRatio: number,
-//       maxDrawdownPct: number,
-//       currentNav: number,                 // neto vrednost imovine fonda (net asset value)
-//       currencyCode: string,
-//     }
-//   - FundStatisticsFilterParams: {
-//       fromDate?: string,   // ISO date — pocetak perioda za obracun
-//       toDate?: string,     // ISO date — kraj perioda za obracun
-//     }
-//
-// Konvencija: pratiti postojecu `Savings` feature celinu kao sablon.
-// Spec: Zadaci_Frontend.pdf, FE4.
+// Tipovi odgovaraju B12 backend ugovoru (FundStatisticsDto / GET /funds/{id}/statistics).
 // ============================================================
 
-export {};
+/**
+ * Statisticke metrike performansi jednog investicionog fonda — odgovor sa
+ * GET /funds/{fundId}/statistics. Mapira se 1:1 iz BE FundStatisticsDto.
+ *
+ * Metrike su `null` kada nema dovoljno istorijskih snimaka da bi bile
+ * smislene (BE prag: MIN_SNAPSHOTS_REQUIRED = 30).
+ */
+export interface FundStatisticsDto {
+  fundId: number;
+  fundName: string;
+  /** Ukupan broj dnevnih snimaka vrednosti koriscenih za obracun. */
+  snapshotCount: number;
+  /** Anualizovani (godisnji) prinos u %. null ako nema dovoljno snimaka. */
+  annualizedReturnPercent: number | null;
+  /** Standardna devijacija mesecnih prinosa u %. null ako nema dovoljno tacaka. */
+  volatilityPercent: number | null;
+  /** Maksimalni pad od vrha do dna u % (negativna vrednost ili 0). null ako nema dovoljno. */
+  maxDrawdownPercent: number | null;
+  /** Sharpe-like racio: annualizedReturn / volatility. null ako volatilnost nije dostupna ili je 0. */
+  rewardToVariabilityRatio: number | null;
+  /** true ako je snapshotCount >= BE prag (dovoljno istorije za pouzdane metrike). */
+  sufficientHistory: boolean;
+}


### PR DESCRIPTION
## FE4 — zadatak 7.2: Statistika fondova

Stranice investicionih fondova proširene metrikama performansi.

### Izmene
- `types/fundStatistics.ts` — `FundStatisticsDto`
- `services/fundStatisticsService.ts` — `getFundStatistics` (`/funds/{id}/statistics`)
- `FundsDiscoveryPage` — 4 nove metričke kolone (godišnji prinos, prinos/rizik, max pad, volatilnost) sa sortiranjem
- `FundDetailsPage` — kartica „Metrike performansi" + uporedni grafik (fond vs prosek svih fondova, indeksirano na 100 na početku perioda)
- Vitest: fundStatisticsService (4) + Discovery (+4) + Details (+3)
- Cypress: celina4-mock statistika fondova (6 scenarija)

### Testiranje
Svih 8 CI provera zeleno.

### Backend (B12)
Servis usklađen sa B12 ugovorom (`/funds/{id}/statistics`). B12 još nije na `main`-u, pa UI graciozno hvata 404 dok ruta ne postane dostupna (spec tačka 1.2 — rad uz mock).
