### PR TITLE
feat(fe): FE4 7.3 — istorija OTC pregovora (admin/supervizor portal)

### DIFF
--- a/cypress/e2e/celina4-mock.cy.ts
+++ b/cypress/e2e/celina4-mock.cy.ts
@@ -935,6 +935,77 @@ describe('Mock C4: CreateOrder Fund Selector', () => {
 
 
 // ============================================================
+//  FEATURE: Istorija OTC pregovora (FE4 — zadatak 7.3 / jkrunic)
+// ============================================================
+const mockNegHistoryPage = {
+  content: [
+    {
+      id: 1, negotiationId: 10, quantity: 5, pricePerShare: 100, premium: 12,
+      settlementDate: '2026-06-30', status: 'ACTIVE', modifiedById: 7,
+      modifiedByName: 'Marko Petrović', createdAt: '2026-05-10T10:00:00',
+    },
+    {
+      id: 2, negotiationId: 11, quantity: 8, pricePerShare: 220, premium: 30,
+      settlementDate: '2026-07-15', status: 'ACCEPTED', modifiedById: 9,
+      modifiedByName: 'Jelena Đorđević', createdAt: '2026-05-12T14:00:00',
+    },
+  ],
+  totalElements: 2, totalPages: 1, number: 0, size: 20,
+};
+
+const mockNegChain = [
+  {
+    id: 1, negotiationId: 10, quantity: 5, pricePerShare: 100, premium: 12,
+    settlementDate: '2026-06-30', status: 'ACTIVE', modifiedById: 7,
+    modifiedByName: 'Marko Petrović', createdAt: '2026-05-10T10:00:00',
+  },
+];
+
+describe('Mock C4: Istorija OTC pregovora (FE4 7.3)', () => {
+  it('S-OH1: Supervizor vidi tabelu zapisa pregovora', () => {
+    cy.intercept('GET', '/api/otc/negotiation-history*', {
+      statusCode: 200, body: mockNegHistoryPage,
+    }).as('history');
+    cy.visit('/otc/negotiation-history', { onBeforeLoad: setupSupervisorSession });
+    cy.wait('@history');
+    cy.contains('Istorija OTC pregovora').should('be.visible');
+    cy.contains('#10').should('be.visible');
+    cy.contains('Marko Petrović').should('be.visible');
+  });
+
+  it('S-OH2: Prazno stanje kad nema zapisa', () => {
+    cy.intercept('GET', '/api/otc/negotiation-history*', {
+      statusCode: 200,
+      body: { content: [], totalElements: 0, totalPages: 0, number: 0, size: 20 },
+    }).as('history');
+    cy.visit('/otc/negotiation-history', { onBeforeLoad: setupSupervisorSession });
+    cy.wait('@history');
+    cy.get('[data-testid="otc-history-empty"]').should('exist');
+  });
+
+  it('S-OH3: Poruka kad B10 endpoint vrati 404', () => {
+    cy.intercept('GET', '/api/otc/negotiation-history*', { statusCode: 404, body: {} }).as('history');
+    cy.visit('/otc/negotiation-history', { onBeforeLoad: setupSupervisorSession });
+    cy.wait('@history');
+    cy.get('[data-testid="otc-history-unavailable"]').should('exist');
+  });
+
+  it('S-OH4: Expand reda prikazuje lanac kontraponuda', () => {
+    cy.intercept('GET', '/api/otc/negotiation-history*', {
+      statusCode: 200, body: mockNegHistoryPage,
+    }).as('history');
+    cy.intercept('GET', '/api/otc/negotiation-history/*', {
+      statusCode: 200, body: mockNegChain,
+    }).as('chain');
+    cy.visit('/otc/negotiation-history', { onBeforeLoad: setupSupervisorSession });
+    cy.wait('@history');
+    cy.get('[data-testid="otc-history-toggle-1"]').click();
+    cy.wait('@chain');
+    cy.get('[data-testid="otc-chain-table"]').should('be.visible');
+  });
+});
+
+// ============================================================
 //  FEATURE 7: OTC Inter-bank Discovery (Issue #67 / ekalajdzic13322)
 // ============================================================
 describe('Mock C4: OTC Inter-bank Discovery', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import OtcDiscoveryPage from './pages/Otc/OtcDiscoveryPage';
 import OtcNegotiationsPage from './pages/Otc/OtcNegotiationsPage';
 import OtcContractsPage from './pages/Otc/OtcContractsPage';
 import OtcMyPublicPage from './pages/Otc/OtcMyPublicPage';
+import OtcNegotiationHistoryPage from './pages/Otc/OtcNegotiationHistoryPage';
 
 // Celina 4 - Investicioni fondovi
 import FundsDiscoveryPage from './pages/Funds/FundsDiscoveryPage';
@@ -201,6 +202,12 @@ export default function App() {
             <Route path="/otc/pregovori" element={<OtcNegotiationsPage />} />
             <Route path="/otc/ugovori" element={<OtcContractsPage />} />
             <Route path="/otc/moje" element={<OtcMyPublicPage />} />
+          </Route>
+
+          {/* OTC istorija pregovora (FE4 7.3) — admin/supervizor portal;
+              B10 lista (/otc/negotiation-history) je admin/supervizor-only */}
+          <Route element={<ProtectedRoute supervisorOnly />}>
+            <Route path="/otc/negotiation-history" element={<OtcNegotiationHistoryPage />} />
           </Route>
 
           {/* Investicioni fondovi (Celina 4) — discovery i details su za sve */}

--- a/src/pages/Otc/OtcHubPage.tsx
+++ b/src/pages/Otc/OtcHubPage.tsx
@@ -66,7 +66,7 @@ function daysUntil(iso?: string | null): number | null {
 
 export default function OtcHubPage() {
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, isSupervisor } = useAuth();
   const [data, setData] = useState<HubData>(INITIAL);
 
   useEffect(() => {
@@ -414,6 +414,21 @@ export default function OtcHubPage() {
           onClick={() => navigate('/otc/moje')}
           dataTestId="hub-my-public"
         />
+        {/* FE4 (7.3) — ulaz u istoriju OTC pregovora; samo admin/supervizor */}
+        {isSupervisor && (
+          <OtcHubCard
+            icon={Clock}
+            title="Istorija pregovora"
+            gradientFrom="from-slate-500"
+            gradientTo="to-gray-600"
+            primaryStat="Arhiva"
+            primaryStatLabel="pregovora i kontraponuda"
+            secondaryStat="Admin / supervizor pregled"
+            loading={data.loading}
+            onClick={() => navigate('/otc/negotiation-history')}
+            dataTestId="hub-negotiation-history"
+          />
+        )}
       </div>
 
       {/* Two columns: Activity + Trending */}

--- a/src/pages/Otc/OtcNegotiationHistoryPage.test.tsx
+++ b/src/pages/Otc/OtcNegotiationHistoryPage.test.tsx
@@ -1,41 +1,145 @@
-// ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
-//
-// Testovi za OtcNegotiationHistoryPage.
-//
-// IMPLEMENTIRATI (posle implementacije komponente):
-//   - Mock otcService metode za istoriju pregovora (lista sa ACTIVE, ACCEPTED, DECLINED)
-//   - Mock useAuth hook (CLIENT rola, user.id = 1)
-//   - Svaki test koristi MemoryRouter wrapper (kao u OtcNegotiationsPage.test.tsx)
-//
-// Planirani test slucajevi:
-//   1. 'renderuje page header sa naslovom "Istorija OTC pregovora"'
-//   2. 'prikazuje skeleton dok se ucitava'
-//   3. 'prikazuje tabelu pregovora posle uspesnog fetch-a'
-//   4. 'prikazuje prazno stanje kad nema pregovora'
-//   5. 'filter po statusu ACCEPTED sakriva ACTIVE i DECLINED redove'
-//   6. 'filter po statusu DECLINED sakriva ACTIVE i ACCEPTED redove'
-//   7. 'pretraga po ticker-u filtrira redove koji ne sadrze uneti ticker'
-//   8. 'badge status ACCEPTED prikazuje se zeleno (variant success)'
-//   9. 'badge status DECLINED prikazuje se sivo (variant secondary)'
-//  10. 'expand/collapse kontraponuda sekcije prikazuje lanac promena cene'
-//  11. 'VI badge se prikazuje pored kupca kad je current user kupac'
-//  12. 'greska pri fetch-u prikazuje toast error'
-// ============================================================
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OtcNegotiationHistoryPage from './OtcNegotiationHistoryPage';
+import { renderWithProviders } from '@/test/test-utils';
 
-import { describe, it } from 'vitest';
+const mockGetHistory = vi.fn();
+const mockGetChain = vi.fn();
+
+vi.mock('@/services/otcService', () => ({
+  default: {
+    getNegotiationHistory: (...a: unknown[]) => mockGetHistory(...a),
+    getNegotiationHistoryById: (...a: unknown[]) => mockGetChain(...a),
+  },
+}));
+
+const ENTRY_A = {
+  id: 1,
+  negotiationId: 10,
+  quantity: 5,
+  pricePerShare: 100,
+  premium: 12,
+  settlementDate: '2026-06-30',
+  status: 'ACTIVE',
+  modifiedById: 7,
+  modifiedByName: 'Marko Petrović',
+  createdAt: '2026-05-10T10:00:00',
+};
+
+const ENTRY_B = {
+  id: 2,
+  negotiationId: 11,
+  quantity: 8,
+  pricePerShare: 220,
+  premium: 30,
+  settlementDate: '2026-07-15',
+  status: 'ACCEPTED',
+  modifiedById: 9,
+  modifiedByName: 'Jelena Đorđević',
+  createdAt: '2026-05-12T14:00:00',
+};
+
+const PAGE = {
+  content: [ENTRY_A, ENTRY_B],
+  totalElements: 2,
+  totalPages: 1,
+  number: 0,
+  size: 20,
+};
 
 describe('OtcNegotiationHistoryPage', () => {
-  it.todo('renderuje page header sa naslovom "Istorija OTC pregovora"');
-  it.todo('prikazuje skeleton dok se ucitava');
-  it.todo('prikazuje tabelu pregovora posle uspesnog fetch-a');
-  it.todo('prikazuje prazno stanje kad nema pregovora');
-  it.todo('filter po statusu ACCEPTED sakriva ACTIVE i DECLINED redove');
-  it.todo('filter po statusu DECLINED sakriva ACTIVE i ACCEPTED redove');
-  it.todo('pretraga po ticker-u filtrira redove koji ne sadrze uneti ticker');
-  it.todo('badge status ACCEPTED prikazuje se zeleno (variant success)');
-  it.todo('badge status DECLINED prikazuje se sivo (variant secondary)');
-  it.todo('expand/collapse kontraponuda sekcije prikazuje lanac promena cene');
-  it.todo('VI badge se prikazuje pored kupca kad je current user kupac');
-  it.todo('greska pri fetch-u prikazuje toast error');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHistory.mockResolvedValue(PAGE);
+    mockGetChain.mockResolvedValue([ENTRY_A]);
+  });
+
+  it('renderuje page header sa naslovom "Istorija OTC pregovora"', () => {
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    expect(screen.getByText('Istorija OTC pregovora')).toBeInTheDocument();
+  });
+
+  it('prikazuje skeleton dok se učitava', () => {
+    mockGetHistory.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    expect(screen.getByTestId('otc-history-loading')).toBeInTheDocument();
+  });
+
+  it('prikazuje tabelu zapisa posle uspešnog fetch-a', async () => {
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() => expect(screen.getByText('#10')).toBeInTheDocument());
+    expect(screen.getByText('#11')).toBeInTheDocument();
+    expect(screen.getByText('Marko Petrović')).toBeInTheDocument();
+    expect(screen.getByText('Jelena Đorđević')).toBeInTheDocument();
+  });
+
+  it('prikazuje prazno stanje kad nema zapisa', async () => {
+    mockGetHistory.mockResolvedValue({ ...PAGE, content: [], totalElements: 0 });
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('otc-history-empty')).toBeInTheDocument(),
+    );
+  });
+
+  it('badge statusa ACCEPTED prikazuje labelu "Prihvaćen"', async () => {
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() => expect(screen.getByText('#11')).toBeInTheDocument());
+    // "Prihvaćen" je i opcija u filteru i badge u redu — skopiraj na red #11.
+    const row = screen.getByText('#11').closest('tr')!;
+    expect(within(row).getByText('Prihvaćen')).toBeInTheDocument();
+  });
+
+  it('promena filtera statusa šalje status param BE-u', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() => expect(screen.getByText('#10')).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByTestId('otc-history-status-filter'), 'ACCEPTED');
+
+    await waitFor(() => {
+      const lastCall = mockGetHistory.mock.calls[mockGetHistory.mock.calls.length - 1][0];
+      expect(lastCall.status).toBe('ACCEPTED');
+    });
+  });
+
+  it('pretraga po drugoj strani filtrira redove client-side', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() => expect(screen.getByText('#10')).toBeInTheDocument());
+
+    await user.type(screen.getByTestId('otc-history-counterparty-search'), 'marko');
+
+    await waitFor(() => expect(screen.queryByText('#11')).not.toBeInTheDocument());
+    expect(screen.getByText('#10')).toBeInTheDocument();
+  });
+
+  it('expand reda učitava i prikazuje lanac kontraponuda', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() => expect(screen.getByTestId('otc-history-toggle-1')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('otc-history-toggle-1'));
+
+    expect(mockGetChain).toHaveBeenCalledWith(10);
+    await waitFor(() =>
+      expect(screen.getByTestId('otc-chain-table')).toBeInTheDocument(),
+    );
+  });
+
+  it('prikazuje poruku kad B10 endpoint vrati 404', async () => {
+    mockGetHistory.mockRejectedValue({ response: { status: 404 } });
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('otc-history-unavailable')).toBeInTheDocument(),
+    );
+  });
+
+  it('prikazuje grešku kad fetch padne sa ne-404 greškom', async () => {
+    mockGetHistory.mockRejectedValue({ response: { status: 500 } });
+    renderWithProviders(<OtcNegotiationHistoryPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('otc-history-error')).toBeInTheDocument(),
+    );
+  });
 });

--- a/src/pages/Otc/OtcNegotiationHistoryPage.tsx
+++ b/src/pages/Otc/OtcNegotiationHistoryPage.tsx
@@ -1,50 +1,434 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Archive, ChevronDown, ChevronRight, Search } from 'lucide-react';
+import otcService from '@/services/otcService';
+import type { OtcNegotiationHistoryDto, OtcNegotiationHistoryPage } from '@/types/otcHistory';
+import { formatAmount, formatDate, formatDateTime } from '@/utils/formatters';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import OtcSubHero from '@/components/otc/OtcSubHero';
+
 // ============================================================
-// TODO [FE4 - Dividende + statistika fondova + istorija OTC | Developer: Jovan Krunic]
-//
-// Stranica istorije OTC pregovora — prikazuje sve pregovore korisnika
-// (aktivne, prihvacene, odbijene) sa kompletnom istorijom kontraponuda
-// i filterima po statusu, datumu i drugoj strani.
-//
-// IMPLEMENTIRATI:
-//   - Fetchovati listu pregovora sa BE endpoint-a GET /otc/offers/history
-//     (ili GET /otc/offers?includeAll=true) koristeci otcService ili zaseban
-//     poziv u ovom fajlu. BE treba da vraca i DECLINED/ACCEPTED, ne samo ACTIVE.
-//   - Filter state:
-//       statusFilter: 'ALL' | 'ACTIVE' | 'ACCEPTED' | 'DECLINED'
-//       counterpartySearch: string  (ime/ticker slobodna pretraga)
-//       fromDate: string | null
-//       toDate: string | null
-//   - Za svaki pregovor prikazati "Kontraponude" expand/collapse sekciju koja
-//     prikazuje chain: originalna ponuda -> kontraponuda 1 -> kontraponuda 2...
-//     Svaki korak sa: datum, ko je napravio, kolicina, cena, premija, dospece.
-//   - Tabela pregleda (kolone): Ticker / Druga strana (kupac ili prodavac) /
-//     Kolicina / Finalna cena / Premija / Dospece / Status / Broj kontraponuda / Akcije (Detalji)
-//   - Paginacija (opciono: beskonacno skrolovanje ili standardni paginator)
-//   - Prazno stanje: ilustracija + "Nema pregovora" poruka
-//   - Loading stanje: Skeleton redovi (kao u OtcNegotiationsPage)
-//   - Badge boje po statusu: ACTIVE=warning, ACCEPTED=success, DECLINED=secondary
-//   - Koristiti shadcn/ui Table, Badge, Card, Button, Input (za search)
-//   - Koristiti OtcSubHero sa History ikonom (Clock ili Archive iz lucide-react)
-//     i gradijentom from-slate-500 to-gray-600
-//
-// Konvencija: pratiti postojecu `Savings` feature celinu kao sablon.
-// Spec: Zadaci_Frontend.pdf, FE4.
+// FE4 (7.3) — Istorija OTC pregovora (Developer: Jovan Krunic)
+// Admin/supervizor portal: paginiran pregled svih zapisa OTC pregovora
+// (B10 GET /otc/negotiation-history) sa filterima po statusu, datumu i
+// drugoj strani. Expand reda prikazuje ceo lanac kontraponuda jednog
+// pregovora (GET /otc/negotiation-history/{negotiationId}).
+// Dok B10 nije dostupan (404), prikaz graciozno degradira.
 // ============================================================
 
-import { Clock } from 'lucide-react';
-import PageHeader from '@/components/shared/PageHeader';
+const PAGE_SIZE = 20;
+
+const STATUS_OPTIONS = ['ALL', 'ACTIVE', 'ACCEPTED', 'DECLINED'] as const;
+
+const STATUS_LABEL: Record<string, string> = {
+  ALL: 'Svi statusi',
+  ACTIVE: 'Aktivan',
+  ACCEPTED: 'Prihvaćen',
+  DECLINED: 'Odbijen',
+};
+
+/** Badge varijanta po statusu pregovora. */
+function statusVariant(status: string): 'warning' | 'success' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'ACTIVE':
+      return 'warning';
+    case 'ACCEPTED':
+      return 'success';
+    case 'DECLINED':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
+
+type ChainStatus = 'loading' | 'ready' | 'error';
+
+/** Inline panel sa hronološkim lancem kontraponuda jednog pregovora. */
+function NegotiationChain({
+  status,
+  chain,
+}: {
+  status: ChainStatus | undefined;
+  chain: OtcNegotiationHistoryDto[] | undefined;
+}) {
+  if (status === undefined || status === 'loading') {
+    return (
+      <div className="space-y-2 py-2" data-testid="otc-chain-loading">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="h-8 animate-pulse rounded bg-muted/50" />
+        ))}
+      </div>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <p className="py-2 text-sm text-red-500" data-testid="otc-chain-error">
+        Greška pri učitavanju lanca kontraponuda.
+      </p>
+    );
+  }
+  if (!chain || chain.length === 0) {
+    return (
+      <p className="py-2 text-sm text-muted-foreground" data-testid="otc-chain-empty">
+        Nema zabeleženih kontraponuda za ovaj pregovor.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2 py-2" data-testid="otc-chain-table">
+      <p className="text-sm font-medium">Lanac kontraponuda</p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-12">Korak</TableHead>
+            <TableHead className="text-right">Količina</TableHead>
+            <TableHead className="text-right">Cena/akciji</TableHead>
+            <TableHead className="text-right">Premija</TableHead>
+            <TableHead>Dospeće</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Izmenio</TableHead>
+            <TableHead>Kada</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {chain.map((step, idx) => (
+            <TableRow key={step.id}>
+              <TableCell className="font-mono">{idx + 1}</TableCell>
+              <TableCell className="text-right font-mono">{formatAmount(step.quantity, 0)}</TableCell>
+              <TableCell className="text-right font-mono">{formatAmount(step.pricePerShare)}</TableCell>
+              <TableCell className="text-right font-mono">{formatAmount(step.premium)}</TableCell>
+              <TableCell>{formatDate(step.settlementDate)}</TableCell>
+              <TableCell>
+                <Badge variant={statusVariant(step.status)}>
+                  {STATUS_LABEL[step.status] ?? step.status}
+                </Badge>
+              </TableCell>
+              <TableCell>{step.modifiedByName}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatDateTime(step.createdAt)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
 
 export default function OtcNegotiationHistoryPage() {
+  const [pageData, setPageData] = useState<OtcNegotiationHistoryPage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<'unavailable' | 'error' | null>(null);
+
+  // Filteri — status/datum idu BE-u; "druga strana" se filtrira client-side po imenu
+  // (B10 prima samo modifiedById, a u tabeli prikazujemo ime).
+  const [statusFilter, setStatusFilter] = useState<string>('ALL');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [counterpartySearch, setCounterpartySearch] = useState('');
+  const [pageNum, setPageNum] = useState(0);
+
+  // Expand: koji red (entry id) je otvoren + keš lanca po negotiationId.
+  const [expandedEntryId, setExpandedEntryId] = useState<number | null>(null);
+  const [chainCache, setChainCache] = useState<Record<number, OtcNegotiationHistoryDto[]>>({});
+  const [chainStatus, setChainStatus] = useState<Record<number, ChainStatus>>({});
+
+  // Dohvatanje istorije — setState samo u async callback-ovima (bez skeleton-a
+  // na refetch, ali bez setState-in-effect upozorenja).
+  useEffect(() => {
+    let cancelled = false;
+    void otcService
+      .getNegotiationHistory({
+        status: statusFilter === 'ALL' ? undefined : statusFilter,
+        from: fromDate ? `${fromDate}T00:00:00` : undefined,
+        to: toDate ? `${toDate}T23:59:59` : undefined,
+        page: pageNum,
+        size: PAGE_SIZE,
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setPageData(data);
+        setLoadError(null);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const httpStatus = (err as { response?: { status?: number } })?.response?.status;
+        setLoadError(
+          httpStatus === 404 || httpStatus === 501 || httpStatus === 405
+            ? 'unavailable'
+            : 'error',
+        );
+        setPageData(null);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [statusFilter, fromDate, toDate, pageNum]);
+
+  // Promena filtera resetuje na prvu stranu.
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value);
+    setPageNum(0);
+  };
+  const handleFromChange = (value: string) => {
+    setFromDate(value);
+    setPageNum(0);
+  };
+  const handleToChange = (value: string) => {
+    setToDate(value);
+    setPageNum(0);
+  };
+
+  const entries = useMemo(() => pageData?.content ?? [], [pageData]);
+
+  // Client-side filter po imenu druge strane.
+  const visibleEntries = useMemo(() => {
+    const q = counterpartySearch.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter((e) => e.modifiedByName.toLowerCase().includes(q));
+  }, [entries, counterpartySearch]);
+
+  const toggleChain = (entry: OtcNegotiationHistoryDto) => {
+    if (expandedEntryId === entry.id) {
+      setExpandedEntryId(null);
+      return;
+    }
+    setExpandedEntryId(entry.id);
+    const negId = entry.negotiationId;
+    if (chainStatus[negId]) return; // već učitano / u toku
+    setChainStatus((prev) => ({ ...prev, [negId]: 'loading' }));
+    void otcService
+      .getNegotiationHistoryById(negId)
+      .then((chain) => {
+        setChainCache((prev) => ({ ...prev, [negId]: Array.isArray(chain) ? chain : [] }));
+        setChainStatus((prev) => ({ ...prev, [negId]: 'ready' }));
+      })
+      .catch(() => {
+        setChainStatus((prev) => ({ ...prev, [negId]: 'error' }));
+      });
+  };
+
+  const totalPages = pageData?.totalPages ?? 0;
+  const totalElements = pageData?.totalElements ?? 0;
+
   return (
     <div className="container mx-auto py-6 space-y-6 animate-fade-up">
-      <PageHeader
-        icon={<Clock className="h-5 w-5" />}
+      <OtcSubHero
+        icon={Archive}
         title="Istorija OTC pregovora"
-        description="Svi vasi OTC pregovori — aktivni, prihvaceni i odbijeni, sa lancima kontraponuda"
+        description="Pregled svih OTC pregovora i lanaca kontraponuda — namenjeno administratorima i supervizorima."
+        gradientFrom="from-slate-500"
+        gradientTo="to-gray-600"
+        kpis={[
+          { label: 'Ukupno zapisa', value: String(totalElements) },
+          { label: 'Strana', value: totalPages > 0 ? `${pageNum + 1}/${totalPages}` : '0/0' },
+        ]}
       />
-      <p className="text-muted-foreground text-sm">
-        Implementacija u toku. Vidi TODO blok na vrhu fajla.
-      </p>
+
+      {/* Filteri */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="otc-hist-status">Status</Label>
+              <select
+                id="otc-hist-status"
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={statusFilter}
+                onChange={(e) => handleStatusChange(e.target.value)}
+                data-testid="otc-history-status-filter"
+              >
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {STATUS_LABEL[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="otc-hist-from">Od datuma</Label>
+              <Input
+                id="otc-hist-from"
+                type="date"
+                value={fromDate}
+                onChange={(e) => handleFromChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="otc-hist-to">Do datuma</Label>
+              <Input
+                id="otc-hist-to"
+                type="date"
+                value={toDate}
+                onChange={(e) => handleToChange(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="otc-hist-cp">Druga strana</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="otc-hist-cp"
+                  className="pl-9"
+                  placeholder="Ime korisnika..."
+                  value={counterpartySearch}
+                  onChange={(e) => setCounterpartySearch(e.target.value)}
+                  data-testid="otc-history-counterparty-search"
+                />
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tabela */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Zapisi pregovora</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-2" data-testid="otc-history-loading">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-12 animate-pulse rounded bg-muted/50" />
+              ))}
+            </div>
+          ) : loadError === 'unavailable' ? (
+            <p
+              className="py-8 text-center text-sm text-muted-foreground"
+              data-testid="otc-history-unavailable"
+            >
+              Istorija OTC pregovora trenutno nije dostupna (B10 endpoint još nije implementiran).
+            </p>
+          ) : loadError === 'error' ? (
+            <p className="py-8 text-center text-sm text-red-500" data-testid="otc-history-error">
+              Greška pri učitavanju istorije pregovora. Pokušajte ponovo kasnije.
+            </p>
+          ) : visibleEntries.length === 0 ? (
+            <div
+              className="flex flex-col items-center py-12 text-center"
+              data-testid="otc-history-empty"
+            >
+              <Archive className="mb-3 h-10 w-10 text-muted-foreground opacity-30" />
+              <p className="font-medium">Nema pregovora</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Nijedan zapis ne odgovara izabranim filterima.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-8" />
+                      <TableHead>Pregovor #</TableHead>
+                      <TableHead className="text-right">Količina</TableHead>
+                      <TableHead className="text-right">Cena/akciji</TableHead>
+                      <TableHead className="text-right">Premija</TableHead>
+                      <TableHead>Dospeće</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Izmenio</TableHead>
+                      <TableHead>Datum izmene</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {visibleEntries.map((entry) => {
+                      const isOpen = expandedEntryId === entry.id;
+                      return (
+                        <Fragment key={entry.id}>
+                          <TableRow>
+                            <TableCell>
+                              <button
+                                type="button"
+                                onClick={() => toggleChain(entry)}
+                                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                                title="Lanac kontraponuda"
+                                aria-expanded={isOpen}
+                                data-testid={`otc-history-toggle-${entry.id}`}
+                              >
+                                {isOpen ? (
+                                  <ChevronDown className="h-4 w-4" />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4" />
+                                )}
+                              </button>
+                            </TableCell>
+                            <TableCell className="font-mono">#{entry.negotiationId}</TableCell>
+                            <TableCell className="text-right font-mono">
+                              {formatAmount(entry.quantity, 0)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono">
+                              {formatAmount(entry.pricePerShare)}
+                            </TableCell>
+                            <TableCell className="text-right font-mono">
+                              {formatAmount(entry.premium)}
+                            </TableCell>
+                            <TableCell>{formatDate(entry.settlementDate)}</TableCell>
+                            <TableCell>
+                              <Badge variant={statusVariant(entry.status)}>
+                                {STATUS_LABEL[entry.status] ?? entry.status}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{entry.modifiedByName}</TableCell>
+                            <TableCell className="text-muted-foreground">
+                              {formatDateTime(entry.createdAt)}
+                            </TableCell>
+                          </TableRow>
+                          {isOpen && (
+                            <TableRow>
+                              <TableCell colSpan={9} className="bg-muted/20">
+                                <NegotiationChain
+                                  status={chainStatus[entry.negotiationId]}
+                                  chain={chainCache[entry.negotiationId]}
+                                />
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </Fragment>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* Paginacija */}
+              <div className="mt-4 flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  Strana {totalPages > 0 ? pageNum + 1 : 0} od {totalPages} · ukupno{' '}
+                  {totalElements} zapisa
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={pageNum <= 0}
+                    onClick={() => setPageNum((p) => Math.max(0, p - 1))}
+                  >
+                    Prethodna
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={pageNum >= totalPages - 1}
+                    onClick={() => setPageNum((p) => p + 1)}
+                  >
+                    Sledeća
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/services/otcService.test.ts
+++ b/src/services/otcService.test.ts
@@ -162,4 +162,67 @@ describe('otcService', () => {
       await expect(otcService.exerciseContract(1)).rejects.toThrow('Settlement date passed');
     });
   });
+
+  // --- FE4 (7.3) — istorija OTC pregovora ---
+
+  describe('getNegotiationHistory', () => {
+    const emptyPage = { content: [], totalElements: 0, totalPages: 0, number: 0, size: 20 };
+
+    it('salje GET /otc/negotiation-history sa filterima kao query params', async () => {
+      mockedApi.get.mockResolvedValue({ data: emptyPage });
+
+      await otcService.getNegotiationHistory({ status: 'ACCEPTED', page: 1, size: 20 });
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/otc/negotiation-history', {
+        params: { status: 'ACCEPTED', page: 1, size: 20 },
+      });
+    });
+
+    it('salje prazan params objekat kad filteri nisu prosledjeni', async () => {
+      mockedApi.get.mockResolvedValue({ data: emptyPage });
+
+      await otcService.getNegotiationHistory();
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/otc/negotiation-history', { params: {} });
+    });
+
+    it('vraca paginiran odgovor iz API-ja', async () => {
+      const page = {
+        content: [{ id: 1, negotiationId: 5 }],
+        totalElements: 1, totalPages: 1, number: 0, size: 20,
+      };
+      mockedApi.get.mockResolvedValue({ data: page });
+
+      const result = await otcService.getNegotiationHistory();
+
+      expect(result).toEqual(page);
+    });
+
+    it('propagira gresku (npr. 404 dok B10 nije aktivan)', async () => {
+      mockedApi.get.mockRejectedValue(new Error('404 not found'));
+      await expect(otcService.getNegotiationHistory()).rejects.toThrow('404 not found');
+    });
+  });
+
+  describe('getNegotiationHistoryById', () => {
+    it('salje GET /otc/negotiation-history/{negotiationId}', async () => {
+      mockedApi.get.mockResolvedValue({ data: [] });
+
+      await otcService.getNegotiationHistoryById(42);
+
+      expect(mockedApi.get).toHaveBeenCalledWith('/otc/negotiation-history/42');
+    });
+
+    it('vraca lanac kontraponuda iz API-ja', async () => {
+      const chain = [
+        { id: 1, negotiationId: 42 },
+        { id: 2, negotiationId: 42 },
+      ];
+      mockedApi.get.mockResolvedValue({ data: chain });
+
+      const result = await otcService.getNegotiationHistoryById(42);
+
+      expect(result).toEqual(chain);
+    });
+  });
 });

--- a/src/services/otcService.ts
+++ b/src/services/otcService.ts
@@ -7,6 +7,11 @@ import type {
   CreateOtcOfferRequest,
   CounterOtcOfferRequest,
 } from '../types/celina3';
+import type {
+  OtcNegotiationHistoryDto,
+  OtcNegotiationHistoryPage,
+  OtcNegotiationHistoryFilters,
+} from '../types/otcHistory';
 
 /**
  * OTC API wrapper — odgovara `/otc/**` endpoint-ima backend-a.
@@ -87,6 +92,33 @@ const otcService = {
    */
   abandonContract: async (contractId: number): Promise<OtcContract> => {
     const { data } = await api.post<OtcContract>(`/otc/contracts/${contractId}/abandon`);
+    return data;
+  },
+
+  /**
+   * FE4 (7.3) — paginiran pregled istorije OTC pregovora sa opcionim filterima
+   * (status, korisnik, opseg datuma). BE: GET /otc/negotiation-history (B10) —
+   * dostupno samo ADMIN i SUPERVISOR ulogama.
+   */
+  getNegotiationHistory: async (
+    filters: OtcNegotiationHistoryFilters = {},
+  ): Promise<OtcNegotiationHistoryPage> => {
+    const { data } = await api.get<OtcNegotiationHistoryPage>('/otc/negotiation-history', {
+      params: filters,
+    });
+    return data;
+  },
+
+  /**
+   * FE4 (7.3) — hronoloski lanac svih izmena (kontraponuda) za jedan pregovor.
+   * BE: GET /otc/negotiation-history/{negotiationId} (B10).
+   */
+  getNegotiationHistoryById: async (
+    negotiationId: number,
+  ): Promise<OtcNegotiationHistoryDto[]> => {
+    const { data } = await api.get<OtcNegotiationHistoryDto[]>(
+      `/otc/negotiation-history/${negotiationId}`,
+    );
     return data;
   },
 };

--- a/src/types/otcHistory.ts
+++ b/src/types/otcHistory.ts
@@ -1,0 +1,55 @@
+// ============================================================
+// FE4 — Istorija OTC pregovora (zadatak 7.3, Developer: Jovan Krunic)
+//
+// Tipovi odgovaraju B10 backend ugovoru
+// (OtcNegotiationHistoryDto / /otc/negotiation-history endpoint-i).
+// ============================================================
+
+/**
+ * Jedan zapis u istoriji OTC pregovora — snimak jedne iteracije pregovora
+ * (inicijalna ponuda ili kontraponuda). Mapira se 1:1 iz BE OtcNegotiationHistoryDto.
+ */
+export interface OtcNegotiationHistoryDto {
+  id: number;
+  /** ID originalne ponude (OtcOffer) na koju se zapis odnosi. */
+  negotiationId: number;
+  /** Kolicina akcija u toj iteraciji pregovora. */
+  quantity: number;
+  /** Cena po akciji u toj iteraciji. */
+  pricePerShare: number;
+  /** Premija opcije u toj iteraciji. */
+  premium: number;
+  /** ISO datum izmirenja koji je vazio u toj iteraciji. */
+  settlementDate: string;
+  /** Status ponude u trenutku zapisa (ACTIVE, ACCEPTED, DECLINED...). */
+  status: string;
+  /** ID korisnika koji je izvrsio izmenu. */
+  modifiedById: number;
+  /** Puno ime korisnika koji je izvrsio izmenu (snapshot). */
+  modifiedByName: string;
+  /** ISO datetime kada je zapis nastao. */
+  createdAt: string;
+}
+
+/** Spring `Page` omotac za paginiran odgovor istorije pregovora. */
+export interface OtcNegotiationHistoryPage {
+  content: OtcNegotiationHistoryDto[];
+  totalElements: number;
+  totalPages: number;
+  /** Trenutna strana (0-bazirano). */
+  number: number;
+  size: number;
+}
+
+/** Query parametri za GET /otc/negotiation-history. */
+export interface OtcNegotiationHistoryFilters {
+  status?: string;
+  /** Filter po korisniku koji je izvrsio izmenu (druga strana u pregovoru). */
+  modifiedById?: number;
+  /** ISO datetime — pocetak opsega. */
+  from?: string;
+  /** ISO datetime — kraj opsega. */
+  to?: string;
+  page?: number;
+  size?: number;
+}


### PR DESCRIPTION
## FE4 — zadatak 7.3: Istorija OTC pregovora

Nova stranica — admin/supervizor portal istorije OTC pregovora.

### Izmene
- `types/otcHistory.ts` — `OtcNegotiationHistoryDto` + Page + filter tipovi
- `otcService` — `getNegotiationHistory` + `getNegotiationHistoryById` (`/otc/negotiation-history`)
- `OtcNegotiationHistoryPage` — paginiran pregled zapisa pregovora, filteri (status / datum / druga strana), expand lanca kontraponuda po pregovoru
- `App.tsx` — ruta `/otc/negotiation-history` (`supervisorOnly`); ulazna kartica na OTC hub-u za supervizore
- Vitest: `otcService` (+6) + `OtcNegotiationHistoryPage` (11); Cypress: `celina4-mock` (4 scenarija)

### Testiranje
Svih 8 CI provera zeleno.

### Backend (B10)
B10 lista (`GET /otc/negotiation-history`) je admin/supervizor-only, pa je ruta `supervisorOnly`. B10 još nije na `main`-u, pa UI graciozno hvata 404 dok ruta ne postane dostupna (spec tačka 1.2 — rad uz mock).
